### PR TITLE
Minor fixes

### DIFF
--- a/generated-sources.json
+++ b/generated-sources.json
@@ -1,6565 +1,6564 @@
 [
     {
-        "type": "file",
-        "url": "https://static.crates.io/crates/Inflector/Inflector-0.11.4.crate",
-        "sha256": "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3",
-        "dest": "cargo/vendor",
-        "dest-filename": "Inflector-0.11.4.crate"
+        "type": "git",
+        "url": "https://github.com/xampprocky/octocrab",
+        "commit": "c78edcd87fa5edcd5a6d0d0878b2a8d020802c40",
+        "dest": "flatpak-cargo/git/octocrab-c78edcd"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "archive",
+        "archive-type": "tar-gzip",
+        "url": "https://static.crates.io/crates/Inflector/Inflector-0.11.4.crate",
+        "sha256": "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3",
+        "dest": "cargo/vendor/Inflector-0.11.4"
+    },
+    {
+        "type": "inline",
+        "contents": "{\"package\": \"fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3\", \"files\": {}}",
         "dest": "cargo/vendor/Inflector-0.11.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ab_glyph/ab_glyph-0.2.17.crate",
         "sha256": "04a9283dace1c41c265496614998d5b9c4a97b3eb770e804f007c5144bf03f2b",
-        "dest": "cargo/vendor",
-        "dest-filename": "ab_glyph-0.2.17.crate"
+        "dest": "cargo/vendor/ab_glyph-0.2.17"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2204a9283dace1c41c265496614998d5b9c4a97b3eb770e804f007c5144bf03f2b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"04a9283dace1c41c265496614998d5b9c4a97b3eb770e804f007c5144bf03f2b\", \"files\": {}}",
         "dest": "cargo/vendor/ab_glyph-0.2.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ab_glyph_rasterizer/ab_glyph_rasterizer-0.1.6.crate",
         "sha256": "363b9b88fad3af3be80bc8f762c9a3f9dfe906fd0327b8e92f1c12e5ae1b8bbb",
-        "dest": "cargo/vendor",
-        "dest-filename": "ab_glyph_rasterizer-0.1.6.crate"
+        "dest": "cargo/vendor/ab_glyph_rasterizer-0.1.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22363b9b88fad3af3be80bc8f762c9a3f9dfe906fd0327b8e92f1c12e5ae1b8bbb%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"363b9b88fad3af3be80bc8f762c9a3f9dfe906fd0327b8e92f1c12e5ae1b8bbb\", \"files\": {}}",
         "dest": "cargo/vendor/ab_glyph_rasterizer-0.1.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/addr2line/addr2line-0.17.0.crate",
         "sha256": "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b",
-        "dest": "cargo/vendor",
-        "dest-filename": "addr2line-0.17.0.crate"
+        "dest": "cargo/vendor/addr2line-0.17.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b\", \"files\": {}}",
         "dest": "cargo/vendor/addr2line-0.17.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/adler/adler-1.0.2.crate",
         "sha256": "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe",
-        "dest": "cargo/vendor",
-        "dest-filename": "adler-1.0.2.crate"
+        "dest": "cargo/vendor/adler-1.0.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe\", \"files\": {}}",
         "dest": "cargo/vendor/adler-1.0.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/adler32/adler32-1.2.0.crate",
         "sha256": "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234",
-        "dest": "cargo/vendor",
-        "dest-filename": "adler32-1.2.0.crate"
+        "dest": "cargo/vendor/adler32-1.2.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234\", \"files\": {}}",
         "dest": "cargo/vendor/adler32-1.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/aead/aead-0.4.3.crate",
         "sha256": "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877",
-        "dest": "cargo/vendor",
-        "dest-filename": "aead-0.4.3.crate"
+        "dest": "cargo/vendor/aead-0.4.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877\", \"files\": {}}",
         "dest": "cargo/vendor/aead-0.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/aes/aes-0.7.5.crate",
         "sha256": "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8",
-        "dest": "cargo/vendor",
-        "dest-filename": "aes-0.7.5.crate"
+        "dest": "cargo/vendor/aes-0.7.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8\", \"files\": {}}",
         "dest": "cargo/vendor/aes-0.7.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/aes-gcm/aes-gcm-0.9.4.crate",
         "sha256": "df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6",
-        "dest": "cargo/vendor",
-        "dest-filename": "aes-gcm-0.9.4.crate"
+        "dest": "cargo/vendor/aes-gcm-0.9.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"df5f85a83a7d8b0442b6aa7b504b8212c1733da07b98aae43d4bc21b2cb3cdf6\", \"files\": {}}",
         "dest": "cargo/vendor/aes-gcm-0.9.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ahash/ahash-0.7.6.crate",
         "sha256": "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47",
-        "dest": "cargo/vendor",
-        "dest-filename": "ahash-0.7.6.crate"
+        "dest": "cargo/vendor/ahash-0.7.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47\", \"files\": {}}",
         "dest": "cargo/vendor/ahash-0.7.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/aho-corasick/aho-corasick-0.7.19.crate",
         "sha256": "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e",
-        "dest": "cargo/vendor",
-        "dest-filename": "aho-corasick-0.7.19.crate"
+        "dest": "cargo/vendor/aho-corasick-0.7.19"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e\", \"files\": {}}",
         "dest": "cargo/vendor/aho-corasick-0.7.19",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/aliasable/aliasable-0.1.3.crate",
         "sha256": "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd",
-        "dest": "cargo/vendor",
-        "dest-filename": "aliasable-0.1.3.crate"
+        "dest": "cargo/vendor/aliasable-0.1.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd\", \"files\": {}}",
         "dest": "cargo/vendor/aliasable-0.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/android_system_properties/android_system_properties-0.1.5.crate",
         "sha256": "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311",
-        "dest": "cargo/vendor",
-        "dest-filename": "android_system_properties-0.1.5.crate"
+        "dest": "cargo/vendor/android_system_properties-0.1.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311\", \"files\": {}}",
         "dest": "cargo/vendor/android_system_properties-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ansi_term/ansi_term-0.12.1.crate",
         "sha256": "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2",
-        "dest": "cargo/vendor",
-        "dest-filename": "ansi_term-0.12.1.crate"
+        "dest": "cargo/vendor/ansi_term-0.12.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2\", \"files\": {}}",
         "dest": "cargo/vendor/ansi_term-0.12.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/approx/approx-0.5.1.crate",
         "sha256": "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6",
-        "dest": "cargo/vendor",
-        "dest-filename": "approx-0.5.1.crate"
+        "dest": "cargo/vendor/approx-0.5.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6\", \"files\": {}}",
         "dest": "cargo/vendor/approx-0.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/arc-swap/arc-swap-1.5.1.crate",
         "sha256": "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164",
-        "dest": "cargo/vendor",
-        "dest-filename": "arc-swap-1.5.1.crate"
+        "dest": "cargo/vendor/arc-swap-1.5.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164\", \"files\": {}}",
         "dest": "cargo/vendor/arc-swap-1.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/arrayvec/arrayvec-0.7.2.crate",
         "sha256": "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6",
-        "dest": "cargo/vendor",
-        "dest-filename": "arrayvec-0.7.2.crate"
+        "dest": "cargo/vendor/arrayvec-0.7.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6\", \"files\": {}}",
         "dest": "cargo/vendor/arrayvec-0.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ash/ash-0.34.0+1.2.203.crate",
         "sha256": "b0f780da53d0063880d45554306489f09dd8d1bda47688b4a57bc579119356df",
-        "dest": "cargo/vendor",
-        "dest-filename": "ash-0.34.0+1.2.203.crate"
+        "dest": "cargo/vendor/ash-0.34.0+1.2.203"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b0f780da53d0063880d45554306489f09dd8d1bda47688b4a57bc579119356df%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b0f780da53d0063880d45554306489f09dd8d1bda47688b4a57bc579119356df\", \"files\": {}}",
         "dest": "cargo/vendor/ash-0.34.0+1.2.203",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/async-stream/async-stream-0.3.3.crate",
         "sha256": "dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e",
-        "dest": "cargo/vendor",
-        "dest-filename": "async-stream-0.3.3.crate"
+        "dest": "cargo/vendor/async-stream-0.3.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"dad5c83079eae9969be7fadefe640a1c566901f05ff91ab221de4b6f68d9507e\", \"files\": {}}",
         "dest": "cargo/vendor/async-stream-0.3.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/async-stream-impl/async-stream-impl-0.3.3.crate",
         "sha256": "10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27",
-        "dest": "cargo/vendor",
-        "dest-filename": "async-stream-impl-0.3.3.crate"
+        "dest": "cargo/vendor/async-stream-impl-0.3.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2210f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"10f203db73a71dfa2fb6dd22763990fa26f3d2625a6da2da900d23b87d26be27\", \"files\": {}}",
         "dest": "cargo/vendor/async-stream-impl-0.3.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/async-trait/async-trait-0.1.57.crate",
         "sha256": "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f",
-        "dest": "cargo/vendor",
-        "dest-filename": "async-trait-0.1.57.crate"
+        "dest": "cargo/vendor/async-trait-0.1.57"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2276464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f\", \"files\": {}}",
         "dest": "cargo/vendor/async-trait-0.1.57",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/atom_syndication/atom_syndication-0.9.1.crate",
         "sha256": "2d5016bf52ff4f3ed28bf3ec1fed96b53daf4b137d5e6b9f97a8cfae7b57a3a2",
-        "dest": "cargo/vendor",
-        "dest-filename": "atom_syndication-0.9.1.crate"
+        "dest": "cargo/vendor/atom_syndication-0.9.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222d5016bf52ff4f3ed28bf3ec1fed96b53daf4b137d5e6b9f97a8cfae7b57a3a2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2d5016bf52ff4f3ed28bf3ec1fed96b53daf4b137d5e6b9f97a8cfae7b57a3a2\", \"files\": {}}",
         "dest": "cargo/vendor/atom_syndication-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/atomic/atomic-0.5.1.crate",
         "sha256": "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c",
-        "dest": "cargo/vendor",
-        "dest-filename": "atomic-0.5.1.crate"
+        "dest": "cargo/vendor/atomic-0.5.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c\", \"files\": {}}",
         "dest": "cargo/vendor/atomic-0.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/atty/atty-0.2.14.crate",
         "sha256": "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
-        "dest": "cargo/vendor",
-        "dest-filename": "atty-0.2.14.crate"
+        "dest": "cargo/vendor/atty-0.2.14"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8\", \"files\": {}}",
         "dest": "cargo/vendor/atty-0.2.14",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/autocfg/autocfg-1.1.0.crate",
         "sha256": "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa",
-        "dest": "cargo/vendor",
-        "dest-filename": "autocfg-1.1.0.crate"
+        "dest": "cargo/vendor/autocfg-1.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa\", \"files\": {}}",
         "dest": "cargo/vendor/autocfg-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/backtrace/backtrace-0.3.66.crate",
         "sha256": "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7",
-        "dest": "cargo/vendor",
-        "dest-filename": "backtrace-0.3.66.crate"
+        "dest": "cargo/vendor/backtrace-0.3.66"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7\", \"files\": {}}",
         "dest": "cargo/vendor/backtrace-0.3.66",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/base64/base64-0.12.3.crate",
         "sha256": "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff",
-        "dest": "cargo/vendor",
-        "dest-filename": "base64-0.12.3.crate"
+        "dest": "cargo/vendor/base64-0.12.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff\", \"files\": {}}",
         "dest": "cargo/vendor/base64-0.12.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/base64/base64-0.13.0.crate",
         "sha256": "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd",
-        "dest": "cargo/vendor",
-        "dest-filename": "base64-0.13.0.crate"
+        "dest": "cargo/vendor/base64-0.13.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd\", \"files\": {}}",
         "dest": "cargo/vendor/base64-0.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/binascii/binascii-0.1.4.crate",
         "sha256": "383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72",
-        "dest": "cargo/vendor",
-        "dest-filename": "binascii-0.1.4.crate"
+        "dest": "cargo/vendor/binascii-0.1.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"383d29d513d8764dcdc42ea295d979eb99c3c9f00607b3692cf68a431f7dca72\", \"files\": {}}",
         "dest": "cargo/vendor/binascii-0.1.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bit-set/bit-set-0.5.3.crate",
         "sha256": "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1",
-        "dest": "cargo/vendor",
-        "dest-filename": "bit-set-0.5.3.crate"
+        "dest": "cargo/vendor/bit-set-0.5.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1\", \"files\": {}}",
         "dest": "cargo/vendor/bit-set-0.5.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bit-vec/bit-vec-0.6.3.crate",
         "sha256": "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb",
-        "dest": "cargo/vendor",
-        "dest-filename": "bit-vec-0.6.3.crate"
+        "dest": "cargo/vendor/bit-vec-0.6.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb\", \"files\": {}}",
         "dest": "cargo/vendor/bit-vec-0.6.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bitflags/bitflags-1.3.2.crate",
         "sha256": "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a",
-        "dest": "cargo/vendor",
-        "dest-filename": "bitflags-1.3.2.crate"
+        "dest": "cargo/vendor/bitflags-1.3.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a\", \"files\": {}}",
         "dest": "cargo/vendor/bitflags-1.3.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/block/block-0.1.6.crate",
         "sha256": "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a",
-        "dest": "cargo/vendor",
-        "dest-filename": "block-0.1.6.crate"
+        "dest": "cargo/vendor/block-0.1.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a\", \"files\": {}}",
         "dest": "cargo/vendor/block-0.1.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/block-buffer/block-buffer-0.10.3.crate",
         "sha256": "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e",
-        "dest": "cargo/vendor",
-        "dest-filename": "block-buffer-0.10.3.crate"
+        "dest": "cargo/vendor/block-buffer-0.10.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2269cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e\", \"files\": {}}",
         "dest": "cargo/vendor/block-buffer-0.10.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bstr/bstr-0.2.17.crate",
         "sha256": "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223",
-        "dest": "cargo/vendor",
-        "dest-filename": "bstr-0.2.17.crate"
+        "dest": "cargo/vendor/bstr-0.2.17"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223\", \"files\": {}}",
         "dest": "cargo/vendor/bstr-0.2.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bumpalo/bumpalo-3.11.0.crate",
         "sha256": "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d",
-        "dest": "cargo/vendor",
-        "dest-filename": "bumpalo-3.11.0.crate"
+        "dest": "cargo/vendor/bumpalo-3.11.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d\", \"files\": {}}",
         "dest": "cargo/vendor/bumpalo-3.11.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bytemuck/bytemuck-1.12.1.crate",
         "sha256": "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da",
-        "dest": "cargo/vendor",
-        "dest-filename": "bytemuck-1.12.1.crate"
+        "dest": "cargo/vendor/bytemuck-1.12.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da\", \"files\": {}}",
         "dest": "cargo/vendor/bytemuck-1.12.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bytemuck_derive/bytemuck_derive-1.2.1.crate",
         "sha256": "1b9e1f5fa78f69496407a27ae9ed989e3c3b072310286f5ef385525e4cbc24a9",
-        "dest": "cargo/vendor",
-        "dest-filename": "bytemuck_derive-1.2.1.crate"
+        "dest": "cargo/vendor/bytemuck_derive-1.2.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%221b9e1f5fa78f69496407a27ae9ed989e3c3b072310286f5ef385525e4cbc24a9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"1b9e1f5fa78f69496407a27ae9ed989e3c3b072310286f5ef385525e4cbc24a9\", \"files\": {}}",
         "dest": "cargo/vendor/bytemuck_derive-1.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/byteorder/byteorder-1.4.3.crate",
         "sha256": "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610",
-        "dest": "cargo/vendor",
-        "dest-filename": "byteorder-1.4.3.crate"
+        "dest": "cargo/vendor/byteorder-1.4.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2214c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610\", \"files\": {}}",
         "dest": "cargo/vendor/byteorder-1.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bytes/bytes-1.1.0.crate",
         "sha256": "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8",
-        "dest": "cargo/vendor",
-        "dest-filename": "bytes-1.1.0.crate"
+        "dest": "cargo/vendor/bytes-1.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8\", \"files\": {}}",
         "dest": "cargo/vendor/bytes-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bytesize/bytesize-1.1.0.crate",
         "sha256": "6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70",
-        "dest": "cargo/vendor",
-        "dest-filename": "bytesize-1.1.0.crate"
+        "dest": "cargo/vendor/bytesize-1.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6c58ec36aac5066d5ca17df51b3e70279f5670a72102f5752cb7e7c856adfc70\", \"files\": {}}",
         "dest": "cargo/vendor/bytesize-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bzip2/bzip2-0.4.3.crate",
         "sha256": "6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0",
-        "dest": "cargo/vendor",
-        "dest-filename": "bzip2-0.4.3.crate"
+        "dest": "cargo/vendor/bzip2-0.4.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6afcd980b5f3a45017c57e57a2fcccbb351cc43a356ce117ef760ef8052b89b0\", \"files\": {}}",
         "dest": "cargo/vendor/bzip2-0.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/bzip2-sys/bzip2-sys-0.1.11+1.0.8.crate",
         "sha256": "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc",
-        "dest": "cargo/vendor",
-        "dest-filename": "bzip2-sys-0.1.11+1.0.8.crate"
+        "dest": "cargo/vendor/bzip2-sys-0.1.11+1.0.8"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc\", \"files\": {}}",
         "dest": "cargo/vendor/bzip2-sys-0.1.11+1.0.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/calloop/calloop-0.9.3.crate",
         "sha256": "bf2eec61efe56aa1e813f5126959296933cf0700030e4314786c48779a66ab82",
-        "dest": "cargo/vendor",
-        "dest-filename": "calloop-0.9.3.crate"
+        "dest": "cargo/vendor/calloop-0.9.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22bf2eec61efe56aa1e813f5126959296933cf0700030e4314786c48779a66ab82%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"bf2eec61efe56aa1e813f5126959296933cf0700030e4314786c48779a66ab82\", \"files\": {}}",
         "dest": "cargo/vendor/calloop-0.9.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cc/cc-1.0.73.crate",
         "sha256": "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11",
-        "dest": "cargo/vendor",
-        "dest-filename": "cc-1.0.73.crate"
+        "dest": "cargo/vendor/cc-1.0.73"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11\", \"files\": {}}",
         "dest": "cargo/vendor/cc-1.0.73",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cfg-if/cfg-if-0.1.10.crate",
         "sha256": "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822",
-        "dest": "cargo/vendor",
-        "dest-filename": "cfg-if-0.1.10.crate"
+        "dest": "cargo/vendor/cfg-if-0.1.10"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822\", \"files\": {}}",
         "dest": "cargo/vendor/cfg-if-0.1.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cfg-if/cfg-if-1.0.0.crate",
         "sha256": "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd",
-        "dest": "cargo/vendor",
-        "dest-filename": "cfg-if-1.0.0.crate"
+        "dest": "cargo/vendor/cfg-if-1.0.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd\", \"files\": {}}",
         "dest": "cargo/vendor/cfg-if-1.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cfg_aliases/cfg_aliases-0.1.1.crate",
         "sha256": "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e",
-        "dest": "cargo/vendor",
-        "dest-filename": "cfg_aliases-0.1.1.crate"
+        "dest": "cargo/vendor/cfg_aliases-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e\", \"files\": {}}",
         "dest": "cargo/vendor/cfg_aliases-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/chrono/chrono-0.4.22.crate",
         "sha256": "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1",
-        "dest": "cargo/vendor",
-        "dest-filename": "chrono-0.4.22.crate"
+        "dest": "cargo/vendor/chrono-0.4.22"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1\", \"files\": {}}",
         "dest": "cargo/vendor/chrono-0.4.22",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cipher/cipher-0.3.0.crate",
         "sha256": "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7",
-        "dest": "cargo/vendor",
-        "dest-filename": "cipher-0.3.0.crate"
+        "dest": "cargo/vendor/cipher-0.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7\", \"files\": {}}",
         "dest": "cargo/vendor/cipher-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/clap/clap-3.2.20.crate",
         "sha256": "23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd",
-        "dest": "cargo/vendor",
-        "dest-filename": "clap-3.2.20.crate"
+        "dest": "cargo/vendor/clap-3.2.20"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2223b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"23b71c3ce99b7611011217b366d923f1d0a7e07a92bb2dbf1e84508c673ca3bd\", \"files\": {}}",
         "dest": "cargo/vendor/clap-3.2.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/clap_derive/clap_derive-3.2.18.crate",
         "sha256": "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65",
-        "dest": "cargo/vendor",
-        "dest-filename": "clap_derive-3.2.18.crate"
+        "dest": "cargo/vendor/clap_derive-3.2.18"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65\", \"files\": {}}",
         "dest": "cargo/vendor/clap_derive-3.2.18",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/clap_lex/clap_lex-0.2.4.crate",
         "sha256": "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5",
-        "dest": "cargo/vendor",
-        "dest-filename": "clap_lex-0.2.4.crate"
+        "dest": "cargo/vendor/clap_lex-0.2.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5\", \"files\": {}}",
         "dest": "cargo/vendor/clap_lex-0.2.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/clipboard-win/clipboard-win-4.4.2.crate",
         "sha256": "c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219",
-        "dest": "cargo/vendor",
-        "dest-filename": "clipboard-win-4.4.2.crate"
+        "dest": "cargo/vendor/clipboard-win-4.4.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c4ab1b92798304eedc095b53942963240037c0516452cb11aeba709d420b2219\", \"files\": {}}",
         "dest": "cargo/vendor/clipboard-win-4.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/clipboard_macos/clipboard_macos-0.1.0.crate",
         "sha256": "145a7f9e9b89453bc0a5e32d166456405d389cea5b578f57f1274b1397588a95",
-        "dest": "cargo/vendor",
-        "dest-filename": "clipboard_macos-0.1.0.crate"
+        "dest": "cargo/vendor/clipboard_macos-0.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22145a7f9e9b89453bc0a5e32d166456405d389cea5b578f57f1274b1397588a95%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"145a7f9e9b89453bc0a5e32d166456405d389cea5b578f57f1274b1397588a95\", \"files\": {}}",
         "dest": "cargo/vendor/clipboard_macos-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/clipboard_wayland/clipboard_wayland-0.2.0.crate",
         "sha256": "6f6364a9f7a66f2ac1a1a098aa1c7f6b686f2496c6ac5e5c0d773445df912747",
-        "dest": "cargo/vendor",
-        "dest-filename": "clipboard_wayland-0.2.0.crate"
+        "dest": "cargo/vendor/clipboard_wayland-0.2.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226f6364a9f7a66f2ac1a1a098aa1c7f6b686f2496c6ac5e5c0d773445df912747%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6f6364a9f7a66f2ac1a1a098aa1c7f6b686f2496c6ac5e5c0d773445df912747\", \"files\": {}}",
         "dest": "cargo/vendor/clipboard_wayland-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/clipboard_x11/clipboard_x11-0.4.0.crate",
         "sha256": "983a7010836ecd04dde2c6d27a0cb56ec5d21572177e782bdcb24a600124e921",
-        "dest": "cargo/vendor",
-        "dest-filename": "clipboard_x11-0.4.0.crate"
+        "dest": "cargo/vendor/clipboard_x11-0.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22983a7010836ecd04dde2c6d27a0cb56ec5d21572177e782bdcb24a600124e921%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"983a7010836ecd04dde2c6d27a0cb56ec5d21572177e782bdcb24a600124e921\", \"files\": {}}",
         "dest": "cargo/vendor/clipboard_x11-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cocoa/cocoa-0.24.0.crate",
         "sha256": "6f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832",
-        "dest": "cargo/vendor",
-        "dest-filename": "cocoa-0.24.0.crate"
+        "dest": "cargo/vendor/cocoa-0.24.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6f63902e9223530efb4e26ccd0cf55ec30d592d3b42e21a28defc42a9586e832\", \"files\": {}}",
         "dest": "cargo/vendor/cocoa-0.24.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cocoa-foundation/cocoa-foundation-0.1.0.crate",
         "sha256": "7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318",
-        "dest": "cargo/vendor",
-        "dest-filename": "cocoa-foundation-0.1.0.crate"
+        "dest": "cargo/vendor/cocoa-foundation-0.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7ade49b65d560ca58c403a479bb396592b155c0185eada742ee323d1d68d6318\", \"files\": {}}",
         "dest": "cargo/vendor/cocoa-foundation-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/codespan-reporting/codespan-reporting-0.11.1.crate",
         "sha256": "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e",
-        "dest": "cargo/vendor",
-        "dest-filename": "codespan-reporting-0.11.1.crate"
+        "dest": "cargo/vendor/codespan-reporting-0.11.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e\", \"files\": {}}",
         "dest": "cargo/vendor/codespan-reporting-0.11.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/color_quant/color_quant-1.1.0.crate",
         "sha256": "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b",
-        "dest": "cargo/vendor",
-        "dest-filename": "color_quant-1.1.0.crate"
+        "dest": "cargo/vendor/color_quant-1.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b\", \"files\": {}}",
         "dest": "cargo/vendor/color_quant-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/console/console-0.15.1.crate",
         "sha256": "89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847",
-        "dest": "cargo/vendor",
-        "dest-filename": "console-0.15.1.crate"
+        "dest": "cargo/vendor/console-0.15.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2289eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"89eab4d20ce20cea182308bca13088fecea9c05f6776cf287205d41a0ed3c847\", \"files\": {}}",
         "dest": "cargo/vendor/console-0.15.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/convert_case/convert_case-0.4.0.crate",
         "sha256": "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e",
-        "dest": "cargo/vendor",
-        "dest-filename": "convert_case-0.4.0.crate"
+        "dest": "cargo/vendor/convert_case-0.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e\", \"files\": {}}",
         "dest": "cargo/vendor/convert_case-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cookie/cookie-0.16.0.crate",
         "sha256": "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05",
-        "dest": "cargo/vendor",
-        "dest-filename": "cookie-0.16.0.crate"
+        "dest": "cargo/vendor/cookie-0.16.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2294d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05\", \"files\": {}}",
         "dest": "cargo/vendor/cookie-0.16.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/copyless/copyless-0.1.5.crate",
         "sha256": "a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536",
-        "dest": "cargo/vendor",
-        "dest-filename": "copyless-0.1.5.crate"
+        "dest": "cargo/vendor/copyless-0.1.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a2df960f5d869b2dd8532793fde43eb5427cceb126c929747a26823ab0eeb536\", \"files\": {}}",
         "dest": "cargo/vendor/copyless-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.7.0.crate",
         "sha256": "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171",
-        "dest": "cargo/vendor",
-        "dest-filename": "core-foundation-0.7.0.crate"
+        "dest": "cargo/vendor/core-foundation-0.7.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2257d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171\", \"files\": {}}",
         "dest": "cargo/vendor/core-foundation-0.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/core-foundation/core-foundation-0.9.3.crate",
         "sha256": "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146",
-        "dest": "cargo/vendor",
-        "dest-filename": "core-foundation-0.9.3.crate"
+        "dest": "cargo/vendor/core-foundation-0.9.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146\", \"files\": {}}",
         "dest": "cargo/vendor/core-foundation-0.9.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.7.0.crate",
         "sha256": "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac",
-        "dest": "cargo/vendor",
-        "dest-filename": "core-foundation-sys-0.7.0.crate"
+        "dest": "cargo/vendor/core-foundation-sys-0.7.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac\", \"files\": {}}",
         "dest": "cargo/vendor/core-foundation-sys-0.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/core-foundation-sys/core-foundation-sys-0.8.3.crate",
         "sha256": "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc",
-        "dest": "cargo/vendor",
-        "dest-filename": "core-foundation-sys-0.8.3.crate"
+        "dest": "cargo/vendor/core-foundation-sys-0.8.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc\", \"files\": {}}",
         "dest": "cargo/vendor/core-foundation-sys-0.8.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/core-graphics/core-graphics-0.19.2.crate",
         "sha256": "b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923",
-        "dest": "cargo/vendor",
-        "dest-filename": "core-graphics-0.19.2.crate"
+        "dest": "cargo/vendor/core-graphics-0.19.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b3889374e6ea6ab25dba90bb5d96202f61108058361f6dc72e8b03e6f8bbe923\", \"files\": {}}",
         "dest": "cargo/vendor/core-graphics-0.19.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/core-graphics/core-graphics-0.22.3.crate",
         "sha256": "2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb",
-        "dest": "cargo/vendor",
-        "dest-filename": "core-graphics-0.22.3.crate"
+        "dest": "cargo/vendor/core-graphics-0.22.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2581bbab3b8ffc6fcbd550bf46c355135d16e9ff2a6ea032ad6b9bf1d7efe4fb\", \"files\": {}}",
         "dest": "cargo/vendor/core-graphics-0.22.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/core-graphics-types/core-graphics-types-0.1.1.crate",
         "sha256": "3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b",
-        "dest": "cargo/vendor",
-        "dest-filename": "core-graphics-types-0.1.1.crate"
+        "dest": "cargo/vendor/core-graphics-types-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3a68b68b3446082644c91ac778bf50cd4104bfb002b5a6a7c44cca5a2c70788b\", \"files\": {}}",
         "dest": "cargo/vendor/core-graphics-types-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/core-video-sys/core-video-sys-0.1.4.crate",
         "sha256": "34ecad23610ad9757664d644e369246edde1803fcb43ed72876565098a5d3828",
-        "dest": "cargo/vendor",
-        "dest-filename": "core-video-sys-0.1.4.crate"
+        "dest": "cargo/vendor/core-video-sys-0.1.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2234ecad23610ad9757664d644e369246edde1803fcb43ed72876565098a5d3828%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"34ecad23610ad9757664d644e369246edde1803fcb43ed72876565098a5d3828\", \"files\": {}}",
         "dest": "cargo/vendor/core-video-sys-0.1.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/country-parser/country-parser-0.1.1.crate",
         "sha256": "1dee23a8308105cbce67c6b9bf85d204949b614bf9286c24f5eebfae50f17b60",
-        "dest": "cargo/vendor",
-        "dest-filename": "country-parser-0.1.1.crate"
+        "dest": "cargo/vendor/country-parser-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%221dee23a8308105cbce67c6b9bf85d204949b614bf9286c24f5eebfae50f17b60%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"1dee23a8308105cbce67c6b9bf85d204949b614bf9286c24f5eebfae50f17b60\", \"files\": {}}",
         "dest": "cargo/vendor/country-parser-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cpufeatures/cpufeatures-0.2.5.crate",
         "sha256": "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320",
-        "dest": "cargo/vendor",
-        "dest-filename": "cpufeatures-0.2.5.crate"
+        "dest": "cargo/vendor/cpufeatures-0.2.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2228d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320\", \"files\": {}}",
         "dest": "cargo/vendor/cpufeatures-0.2.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crc32fast/crc32fast-1.3.2.crate",
         "sha256": "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d",
-        "dest": "cargo/vendor",
-        "dest-filename": "crc32fast-1.3.2.crate"
+        "dest": "cargo/vendor/crc32fast-1.3.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d\", \"files\": {}}",
         "dest": "cargo/vendor/crc32fast-1.3.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crossbeam-channel/crossbeam-channel-0.5.6.crate",
         "sha256": "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521",
-        "dest": "cargo/vendor",
-        "dest-filename": "crossbeam-channel-0.5.6.crate"
+        "dest": "cargo/vendor/crossbeam-channel-0.5.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521\", \"files\": {}}",
         "dest": "cargo/vendor/crossbeam-channel-0.5.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crossbeam-deque/crossbeam-deque-0.8.2.crate",
         "sha256": "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc",
-        "dest": "cargo/vendor",
-        "dest-filename": "crossbeam-deque-0.8.2.crate"
+        "dest": "cargo/vendor/crossbeam-deque-0.8.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc\", \"files\": {}}",
         "dest": "cargo/vendor/crossbeam-deque-0.8.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crossbeam-epoch/crossbeam-epoch-0.9.10.crate",
         "sha256": "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1",
-        "dest": "cargo/vendor",
-        "dest-filename": "crossbeam-epoch-0.9.10.crate"
+        "dest": "cargo/vendor/crossbeam-epoch-0.9.10"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1\", \"files\": {}}",
         "dest": "cargo/vendor/crossbeam-epoch-0.9.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crossbeam-utils/crossbeam-utils-0.8.11.crate",
         "sha256": "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc",
-        "dest": "cargo/vendor",
-        "dest-filename": "crossbeam-utils-0.8.11.crate"
+        "dest": "cargo/vendor/crossbeam-utils-0.8.11"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2251887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc\", \"files\": {}}",
         "dest": "cargo/vendor/crossbeam-utils-0.8.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/crypto-common/crypto-common-0.1.6.crate",
         "sha256": "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3",
-        "dest": "cargo/vendor",
-        "dest-filename": "crypto-common-0.1.6.crate"
+        "dest": "cargo/vendor/crypto-common-0.1.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%221bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3\", \"files\": {}}",
         "dest": "cargo/vendor/crypto-common-0.1.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ctr/ctr-0.8.0.crate",
         "sha256": "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea",
-        "dest": "cargo/vendor",
-        "dest-filename": "ctr-0.8.0.crate"
+        "dest": "cargo/vendor/ctr-0.8.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea\", \"files\": {}}",
         "dest": "cargo/vendor/ctr-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/cty/cty-0.2.2.crate",
         "sha256": "b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35",
-        "dest": "cargo/vendor",
-        "dest-filename": "cty-0.2.2.crate"
+        "dest": "cargo/vendor/cty-0.2.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b365fabc795046672053e29c954733ec3b05e4be654ab130fe8f1f94d7051f35\", \"files\": {}}",
         "dest": "cargo/vendor/cty-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/d3d12/d3d12-0.4.1.crate",
         "sha256": "2daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c",
-        "dest": "cargo/vendor",
-        "dest-filename": "d3d12-0.4.1.crate"
+        "dest": "cargo/vendor/d3d12-0.4.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2daefd788d1e96e0a9d66dee4b828b883509bc3ea9ce30665f04c3246372690c\", \"files\": {}}",
         "dest": "cargo/vendor/d3d12-0.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/darling/darling-0.10.2.crate",
         "sha256": "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858",
-        "dest": "cargo/vendor",
-        "dest-filename": "darling-0.10.2.crate"
+        "dest": "cargo/vendor/darling-0.10.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858\", \"files\": {}}",
         "dest": "cargo/vendor/darling-0.10.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/darling/darling-0.13.4.crate",
         "sha256": "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c",
-        "dest": "cargo/vendor",
-        "dest-filename": "darling-0.13.4.crate"
+        "dest": "cargo/vendor/darling-0.13.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c\", \"files\": {}}",
         "dest": "cargo/vendor/darling-0.13.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/darling_core/darling_core-0.10.2.crate",
         "sha256": "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b",
-        "dest": "cargo/vendor",
-        "dest-filename": "darling_core-0.10.2.crate"
+        "dest": "cargo/vendor/darling_core-0.10.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b\", \"files\": {}}",
         "dest": "cargo/vendor/darling_core-0.10.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/darling_core/darling_core-0.13.4.crate",
         "sha256": "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610",
-        "dest": "cargo/vendor",
-        "dest-filename": "darling_core-0.13.4.crate"
+        "dest": "cargo/vendor/darling_core-0.13.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610\", \"files\": {}}",
         "dest": "cargo/vendor/darling_core-0.13.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/darling_macro/darling_macro-0.10.2.crate",
         "sha256": "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72",
-        "dest": "cargo/vendor",
-        "dest-filename": "darling_macro-0.10.2.crate"
+        "dest": "cargo/vendor/darling_macro-0.10.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72\", \"files\": {}}",
         "dest": "cargo/vendor/darling_macro-0.10.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/darling_macro/darling_macro-0.13.4.crate",
         "sha256": "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835",
-        "dest": "cargo/vendor",
-        "dest-filename": "darling_macro-0.13.4.crate"
+        "dest": "cargo/vendor/darling_macro-0.13.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835\", \"files\": {}}",
         "dest": "cargo/vendor/darling_macro-0.13.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/deflate/deflate-0.8.6.crate",
         "sha256": "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174",
-        "dest": "cargo/vendor",
-        "dest-filename": "deflate-0.8.6.crate"
+        "dest": "cargo/vendor/deflate-0.8.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2273770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174\", \"files\": {}}",
         "dest": "cargo/vendor/deflate-0.8.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/derive_builder/derive_builder-0.9.0.crate",
         "sha256": "a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0",
-        "dest": "cargo/vendor",
-        "dest-filename": "derive_builder-0.9.0.crate"
+        "dest": "cargo/vendor/derive_builder-0.9.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a2658621297f2cf68762a6f7dc0bb7e1ff2cfd6583daef8ee0fed6f7ec468ec0\", \"files\": {}}",
         "dest": "cargo/vendor/derive_builder-0.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/derive_builder_core/derive_builder_core-0.9.0.crate",
         "sha256": "2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef",
-        "dest": "cargo/vendor",
-        "dest-filename": "derive_builder_core-0.9.0.crate"
+        "dest": "cargo/vendor/derive_builder_core-0.9.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2791ea3e372c8495c0bc2033991d76b512cd799d07491fbd6890124db9458bef\", \"files\": {}}",
         "dest": "cargo/vendor/derive_builder_core-0.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/derive_more/derive_more-0.99.17.crate",
         "sha256": "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321",
-        "dest": "cargo/vendor",
-        "dest-filename": "derive_more-0.99.17.crate"
+        "dest": "cargo/vendor/derive_more-0.99.17"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321\", \"files\": {}}",
         "dest": "cargo/vendor/derive_more-0.99.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/devise/devise-0.3.1.crate",
         "sha256": "50c7580b072f1c8476148f16e0a0d5dedddab787da98d86c5082c5e9ed8ab595",
-        "dest": "cargo/vendor",
-        "dest-filename": "devise-0.3.1.crate"
+        "dest": "cargo/vendor/devise-0.3.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2250c7580b072f1c8476148f16e0a0d5dedddab787da98d86c5082c5e9ed8ab595%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"50c7580b072f1c8476148f16e0a0d5dedddab787da98d86c5082c5e9ed8ab595\", \"files\": {}}",
         "dest": "cargo/vendor/devise-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/devise_codegen/devise_codegen-0.3.1.crate",
         "sha256": "123c73e7a6e51b05c75fe1a1b2f4e241399ea5740ed810b0e3e6cacd9db5e7b2",
-        "dest": "cargo/vendor",
-        "dest-filename": "devise_codegen-0.3.1.crate"
+        "dest": "cargo/vendor/devise_codegen-0.3.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22123c73e7a6e51b05c75fe1a1b2f4e241399ea5740ed810b0e3e6cacd9db5e7b2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"123c73e7a6e51b05c75fe1a1b2f4e241399ea5740ed810b0e3e6cacd9db5e7b2\", \"files\": {}}",
         "dest": "cargo/vendor/devise_codegen-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/devise_core/devise_core-0.3.1.crate",
         "sha256": "841ef46f4787d9097405cac4e70fb8644fc037b526e8c14054247c0263c400d0",
-        "dest": "cargo/vendor",
-        "dest-filename": "devise_core-0.3.1.crate"
+        "dest": "cargo/vendor/devise_core-0.3.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22841ef46f4787d9097405cac4e70fb8644fc037b526e8c14054247c0263c400d0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"841ef46f4787d9097405cac4e70fb8644fc037b526e8c14054247c0263c400d0\", \"files\": {}}",
         "dest": "cargo/vendor/devise_core-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/diesel/diesel-1.4.8.crate",
         "sha256": "b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d",
-        "dest": "cargo/vendor",
-        "dest-filename": "diesel-1.4.8.crate"
+        "dest": "cargo/vendor/diesel-1.4.8"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b28135ecf6b7d446b43e27e225622a038cc4e2930a1022f51cdb97ada19b8e4d\", \"files\": {}}",
         "dest": "cargo/vendor/diesel-1.4.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/diesel_derives/diesel_derives-1.4.1.crate",
         "sha256": "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3",
-        "dest": "cargo/vendor",
-        "dest-filename": "diesel_derives-1.4.1.crate"
+        "dest": "cargo/vendor/diesel_derives-1.4.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2245f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3\", \"files\": {}}",
         "dest": "cargo/vendor/diesel_derives-1.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/diesel_migrations/diesel_migrations-1.4.0.crate",
         "sha256": "bf3cde8413353dc7f5d72fa8ce0b99a560a359d2c5ef1e5817ca731cd9008f4c",
-        "dest": "cargo/vendor",
-        "dest-filename": "diesel_migrations-1.4.0.crate"
+        "dest": "cargo/vendor/diesel_migrations-1.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22bf3cde8413353dc7f5d72fa8ce0b99a560a359d2c5ef1e5817ca731cd9008f4c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"bf3cde8413353dc7f5d72fa8ce0b99a560a359d2c5ef1e5817ca731cd9008f4c\", \"files\": {}}",
         "dest": "cargo/vendor/diesel_migrations-1.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/digest/digest-0.10.3.crate",
         "sha256": "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506",
-        "dest": "cargo/vendor",
-        "dest-filename": "digest-0.10.3.crate"
+        "dest": "cargo/vendor/digest-0.10.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506\", \"files\": {}}",
         "dest": "cargo/vendor/digest-0.10.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/diligent-date-parser/diligent-date-parser-0.1.3.crate",
         "sha256": "c2d0fd95c7c02e2d6c588c6c5628466fff9bdde4b8c6196465e087b08e792720",
-        "dest": "cargo/vendor",
-        "dest-filename": "diligent-date-parser-0.1.3.crate"
+        "dest": "cargo/vendor/diligent-date-parser-0.1.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c2d0fd95c7c02e2d6c588c6c5628466fff9bdde4b8c6196465e087b08e792720%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c2d0fd95c7c02e2d6c588c6c5628466fff9bdde4b8c6196465e087b08e792720\", \"files\": {}}",
         "dest": "cargo/vendor/diligent-date-parser-0.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/dirs-next/dirs-next-2.0.0.crate",
         "sha256": "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1",
-        "dest": "cargo/vendor",
-        "dest-filename": "dirs-next-2.0.0.crate"
+        "dest": "cargo/vendor/dirs-next-2.0.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1\", \"files\": {}}",
         "dest": "cargo/vendor/dirs-next-2.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/dirs-sys-next/dirs-sys-next-0.1.2.crate",
         "sha256": "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d",
-        "dest": "cargo/vendor",
-        "dest-filename": "dirs-sys-next-0.1.2.crate"
+        "dest": "cargo/vendor/dirs-sys-next-0.1.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d\", \"files\": {}}",
         "dest": "cargo/vendor/dirs-sys-next-0.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/dispatch/dispatch-0.2.0.crate",
         "sha256": "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b",
-        "dest": "cargo/vendor",
-        "dest-filename": "dispatch-0.2.0.crate"
+        "dest": "cargo/vendor/dispatch-0.2.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b\", \"files\": {}}",
         "dest": "cargo/vendor/dispatch-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/dlib/dlib-0.5.0.crate",
         "sha256": "ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794",
-        "dest": "cargo/vendor",
-        "dest-filename": "dlib-0.5.0.crate"
+        "dest": "cargo/vendor/dlib-0.5.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ac1b7517328c04c2aa68422fc60a41b92208182142ed04a25879c26c8f878794\", \"files\": {}}",
         "dest": "cargo/vendor/dlib-0.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/doc-comment/doc-comment-0.3.3.crate",
         "sha256": "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10",
-        "dest": "cargo/vendor",
-        "dest-filename": "doc-comment-0.3.3.crate"
+        "dest": "cargo/vendor/doc-comment-0.3.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10\", \"files\": {}}",
         "dest": "cargo/vendor/doc-comment-0.3.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/dotenv/dotenv-0.15.0.crate",
         "sha256": "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f",
-        "dest": "cargo/vendor",
-        "dest-filename": "dotenv-0.15.0.crate"
+        "dest": "cargo/vendor/dotenv-0.15.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2277c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f\", \"files\": {}}",
         "dest": "cargo/vendor/dotenv-0.15.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/downcast-rs/downcast-rs-1.2.0.crate",
         "sha256": "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650",
-        "dest": "cargo/vendor",
-        "dest-filename": "downcast-rs-1.2.0.crate"
+        "dest": "cargo/vendor/downcast-rs-1.2.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650\", \"files\": {}}",
         "dest": "cargo/vendor/downcast-rs-1.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/either/either-1.8.0.crate",
         "sha256": "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797",
-        "dest": "cargo/vendor",
-        "dest-filename": "either-1.8.0.crate"
+        "dest": "cargo/vendor/either-1.8.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2290e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797\", \"files\": {}}",
         "dest": "cargo/vendor/either-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/encode_unicode/encode_unicode-0.3.6.crate",
         "sha256": "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f",
-        "dest": "cargo/vendor",
-        "dest-filename": "encode_unicode-0.3.6.crate"
+        "dest": "cargo/vendor/encode_unicode-0.3.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f\", \"files\": {}}",
         "dest": "cargo/vendor/encode_unicode-0.3.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/encoding_rs/encoding_rs-0.8.31.crate",
         "sha256": "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b",
-        "dest": "cargo/vendor",
-        "dest-filename": "encoding_rs-0.8.31.crate"
+        "dest": "cargo/vendor/encoding_rs-0.8.31"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b\", \"files\": {}}",
         "dest": "cargo/vendor/encoding_rs-0.8.31",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/error-code/error-code-2.3.1.crate",
         "sha256": "64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21",
-        "dest": "cargo/vendor",
-        "dest-filename": "error-code-2.3.1.crate"
+        "dest": "cargo/vendor/error-code-2.3.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2264f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"64f18991e7bf11e7ffee451b5318b5c1a73c52d0d0ada6e5a3017c8c1ced6a21\", \"files\": {}}",
         "dest": "cargo/vendor/error-code-2.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/euclid/euclid-0.22.7.crate",
         "sha256": "b52c2ef4a78da0ba68fbe1fd920627411096d2ac478f7f4c9f3a54ba6705bade",
-        "dest": "cargo/vendor",
-        "dest-filename": "euclid-0.22.7.crate"
+        "dest": "cargo/vendor/euclid-0.22.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b52c2ef4a78da0ba68fbe1fd920627411096d2ac478f7f4c9f3a54ba6705bade%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b52c2ef4a78da0ba68fbe1fd920627411096d2ac478f7f4c9f3a54ba6705bade\", \"files\": {}}",
         "dest": "cargo/vendor/euclid-0.22.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/fastrand/fastrand-1.8.0.crate",
         "sha256": "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499",
-        "dest": "cargo/vendor",
-        "dest-filename": "fastrand-1.8.0.crate"
+        "dest": "cargo/vendor/fastrand-1.8.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499\", \"files\": {}}",
         "dest": "cargo/vendor/fastrand-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/figment/figment-0.10.7.crate",
         "sha256": "6e3bd154d9ae2f1bb0ada5b7eebd56529513efa5de7d2fc8c6adf33bc43260cf",
-        "dest": "cargo/vendor",
-        "dest-filename": "figment-0.10.7.crate"
+        "dest": "cargo/vendor/figment-0.10.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226e3bd154d9ae2f1bb0ada5b7eebd56529513efa5de7d2fc8c6adf33bc43260cf%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6e3bd154d9ae2f1bb0ada5b7eebd56529513efa5de7d2fc8c6adf33bc43260cf\", \"files\": {}}",
         "dest": "cargo/vendor/figment-0.10.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/find_folder/find_folder-0.3.0.crate",
         "sha256": "9f6d018fb95a0b59f854aed68ecd96ce2b80af7911b92b1fed3c4b1fa516b91b",
-        "dest": "cargo/vendor",
-        "dest-filename": "find_folder-0.3.0.crate"
+        "dest": "cargo/vendor/find_folder-0.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229f6d018fb95a0b59f854aed68ecd96ce2b80af7911b92b1fed3c4b1fa516b91b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9f6d018fb95a0b59f854aed68ecd96ce2b80af7911b92b1fed3c4b1fa516b91b\", \"files\": {}}",
         "dest": "cargo/vendor/find_folder-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/flate2/flate2-1.0.24.crate",
         "sha256": "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6",
-        "dest": "cargo/vendor",
-        "dest-filename": "flate2-1.0.24.crate"
+        "dest": "cargo/vendor/flate2-1.0.24"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6\", \"files\": {}}",
         "dest": "cargo/vendor/flate2-1.0.24",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/fnv/fnv-1.0.7.crate",
         "sha256": "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1",
-        "dest": "cargo/vendor",
-        "dest-filename": "fnv-1.0.7.crate"
+        "dest": "cargo/vendor/fnv-1.0.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1\", \"files\": {}}",
         "dest": "cargo/vendor/fnv-1.0.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/foreign-types/foreign-types-0.3.2.crate",
         "sha256": "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1",
-        "dest": "cargo/vendor",
-        "dest-filename": "foreign-types-0.3.2.crate"
+        "dest": "cargo/vendor/foreign-types-0.3.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1\", \"files\": {}}",
         "dest": "cargo/vendor/foreign-types-0.3.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/foreign-types-shared/foreign-types-shared-0.1.1.crate",
         "sha256": "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b",
-        "dest": "cargo/vendor",
-        "dest-filename": "foreign-types-shared-0.1.1.crate"
+        "dest": "cargo/vendor/foreign-types-shared-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2200b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b\", \"files\": {}}",
         "dest": "cargo/vendor/foreign-types-shared-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/form_urlencoded/form_urlencoded-1.0.1.crate",
         "sha256": "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191",
-        "dest": "cargo/vendor",
-        "dest-filename": "form_urlencoded-1.0.1.crate"
+        "dest": "cargo/vendor/form_urlencoded-1.0.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191\", \"files\": {}}",
         "dest": "cargo/vendor/form_urlencoded-1.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futf/futf-0.1.5.crate",
         "sha256": "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843",
-        "dest": "cargo/vendor",
-        "dest-filename": "futf-0.1.5.crate"
+        "dest": "cargo/vendor/futf-0.1.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843\", \"files\": {}}",
         "dest": "cargo/vendor/futf-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures/futures-0.3.24.crate",
         "sha256": "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-0.3.24.crate"
+        "dest": "cargo/vendor/futures-0.3.24"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c\", \"files\": {}}",
         "dest": "cargo/vendor/futures-0.3.24",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-channel/futures-channel-0.3.24.crate",
         "sha256": "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-channel-0.3.24.crate"
+        "dest": "cargo/vendor/futures-channel-0.3.24"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2230bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050\", \"files\": {}}",
         "dest": "cargo/vendor/futures-channel-0.3.24",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-core/futures-core-0.3.24.crate",
         "sha256": "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-core-0.3.24.crate"
+        "dest": "cargo/vendor/futures-core-0.3.24"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf\", \"files\": {}}",
         "dest": "cargo/vendor/futures-core-0.3.24",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-executor/futures-executor-0.3.24.crate",
         "sha256": "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-executor-0.3.24.crate"
+        "dest": "cargo/vendor/futures-executor-0.3.24"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab\", \"files\": {}}",
         "dest": "cargo/vendor/futures-executor-0.3.24",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-io/futures-io-0.3.24.crate",
         "sha256": "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-io-0.3.24.crate"
+        "dest": "cargo/vendor/futures-io-0.3.24"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68\", \"files\": {}}",
         "dest": "cargo/vendor/futures-io-0.3.24",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-macro/futures-macro-0.3.24.crate",
         "sha256": "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-macro-0.3.24.crate"
+        "dest": "cargo/vendor/futures-macro-0.3.24"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2242cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17\", \"files\": {}}",
         "dest": "cargo/vendor/futures-macro-0.3.24",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-sink/futures-sink-0.3.24.crate",
         "sha256": "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-sink-0.3.24.crate"
+        "dest": "cargo/vendor/futures-sink-0.3.24"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2221b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56\", \"files\": {}}",
         "dest": "cargo/vendor/futures-sink-0.3.24",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-task/futures-task-0.3.24.crate",
         "sha256": "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-task-0.3.24.crate"
+        "dest": "cargo/vendor/futures-task-0.3.24"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1\", \"files\": {}}",
         "dest": "cargo/vendor/futures-task-0.3.24",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/futures-util/futures-util-0.3.24.crate",
         "sha256": "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90",
-        "dest": "cargo/vendor",
-        "dest-filename": "futures-util-0.3.24.crate"
+        "dest": "cargo/vendor/futures-util-0.3.24"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2244fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90\", \"files\": {}}",
         "dest": "cargo/vendor/futures-util-0.3.24",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/fxhash/fxhash-0.2.1.crate",
         "sha256": "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c",
-        "dest": "cargo/vendor",
-        "dest-filename": "fxhash-0.2.1.crate"
+        "dest": "cargo/vendor/fxhash-0.2.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c\", \"files\": {}}",
         "dest": "cargo/vendor/fxhash-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/generator/generator-0.7.1.crate",
         "sha256": "cc184cace1cea8335047a471cc1da80f18acf8a76f3bab2028d499e328948ec7",
-        "dest": "cargo/vendor",
-        "dest-filename": "generator-0.7.1.crate"
+        "dest": "cargo/vendor/generator-0.7.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22cc184cace1cea8335047a471cc1da80f18acf8a76f3bab2028d499e328948ec7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"cc184cace1cea8335047a471cc1da80f18acf8a76f3bab2028d499e328948ec7\", \"files\": {}}",
         "dest": "cargo/vendor/generator-0.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/generic-array/generic-array-0.14.6.crate",
         "sha256": "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9",
-        "dest": "cargo/vendor",
-        "dest-filename": "generic-array-0.14.6.crate"
+        "dest": "cargo/vendor/generic-array-0.14.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9\", \"files\": {}}",
         "dest": "cargo/vendor/generic-array-0.14.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/gethostname/gethostname-0.2.3.crate",
         "sha256": "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e",
-        "dest": "cargo/vendor",
-        "dest-filename": "gethostname-0.2.3.crate"
+        "dest": "cargo/vendor/gethostname-0.2.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e\", \"files\": {}}",
         "dest": "cargo/vendor/gethostname-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/getopts/getopts-0.2.21.crate",
         "sha256": "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5",
-        "dest": "cargo/vendor",
-        "dest-filename": "getopts-0.2.21.crate"
+        "dest": "cargo/vendor/getopts-0.2.21"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2214dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5\", \"files\": {}}",
         "dest": "cargo/vendor/getopts-0.2.21",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/getrandom/getrandom-0.1.16.crate",
         "sha256": "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce",
-        "dest": "cargo/vendor",
-        "dest-filename": "getrandom-0.1.16.crate"
+        "dest": "cargo/vendor/getrandom-0.1.16"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce\", \"files\": {}}",
         "dest": "cargo/vendor/getrandom-0.1.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/getrandom/getrandom-0.2.7.crate",
         "sha256": "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6",
-        "dest": "cargo/vendor",
-        "dest-filename": "getrandom-0.2.7.crate"
+        "dest": "cargo/vendor/getrandom-0.2.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6\", \"files\": {}}",
         "dest": "cargo/vendor/getrandom-0.2.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ghash/ghash-0.4.4.crate",
         "sha256": "1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99",
-        "dest": "cargo/vendor",
-        "dest-filename": "ghash-0.4.4.crate"
+        "dest": "cargo/vendor/ghash-0.4.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%221583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"1583cc1656d7839fd3732b80cf4f38850336cdb9b8ded1cd399ca62958de3c99\", \"files\": {}}",
         "dest": "cargo/vendor/ghash-0.4.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/gif/gif-0.11.4.crate",
         "sha256": "3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06",
-        "dest": "cargo/vendor",
-        "dest-filename": "gif-0.11.4.crate"
+        "dest": "cargo/vendor/gif-0.11.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06\", \"files\": {}}",
         "dest": "cargo/vendor/gif-0.11.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/gimli/gimli-0.26.2.crate",
         "sha256": "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d",
-        "dest": "cargo/vendor",
-        "dest-filename": "gimli-0.26.2.crate"
+        "dest": "cargo/vendor/gimli-0.26.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2222030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d\", \"files\": {}}",
         "dest": "cargo/vendor/gimli-0.26.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/glam/glam-0.10.2.crate",
         "sha256": "579160312273c954cc51bd440f059dde741029ac8daf8c84fece76cb77f62c15",
-        "dest": "cargo/vendor",
-        "dest-filename": "glam-0.10.2.crate"
+        "dest": "cargo/vendor/glam-0.10.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22579160312273c954cc51bd440f059dde741029ac8daf8c84fece76cb77f62c15%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"579160312273c954cc51bd440f059dde741029ac8daf8c84fece76cb77f62c15\", \"files\": {}}",
         "dest": "cargo/vendor/glam-0.10.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/glob/glob-0.3.0.crate",
         "sha256": "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574",
-        "dest": "cargo/vendor",
-        "dest-filename": "glob-0.3.0.crate"
+        "dest": "cargo/vendor/glob-0.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574\", \"files\": {}}",
         "dest": "cargo/vendor/glob-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/glow/glow-0.11.2.crate",
         "sha256": "d8bd5877156a19b8ac83a29b2306fe20537429d318f3ff0a1a2119f8d9c61919",
-        "dest": "cargo/vendor",
-        "dest-filename": "glow-0.11.2.crate"
+        "dest": "cargo/vendor/glow-0.11.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d8bd5877156a19b8ac83a29b2306fe20537429d318f3ff0a1a2119f8d9c61919%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d8bd5877156a19b8ac83a29b2306fe20537429d318f3ff0a1a2119f8d9c61919\", \"files\": {}}",
         "dest": "cargo/vendor/glow-0.11.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/glyph_brush/glyph_brush-0.7.5.crate",
         "sha256": "ac02497410cdb5062cc056a33f2e1e19ff69fbf26a4be9a02bf29d6e17ea105b",
-        "dest": "cargo/vendor",
-        "dest-filename": "glyph_brush-0.7.5.crate"
+        "dest": "cargo/vendor/glyph_brush-0.7.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ac02497410cdb5062cc056a33f2e1e19ff69fbf26a4be9a02bf29d6e17ea105b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ac02497410cdb5062cc056a33f2e1e19ff69fbf26a4be9a02bf29d6e17ea105b\", \"files\": {}}",
         "dest": "cargo/vendor/glyph_brush-0.7.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/glyph_brush_draw_cache/glyph_brush_draw_cache-0.1.5.crate",
         "sha256": "6010675390f6889e09a21e2c8b575b3ee25667ea8237a8d59423f73cb8c28610",
-        "dest": "cargo/vendor",
-        "dest-filename": "glyph_brush_draw_cache-0.1.5.crate"
+        "dest": "cargo/vendor/glyph_brush_draw_cache-0.1.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226010675390f6889e09a21e2c8b575b3ee25667ea8237a8d59423f73cb8c28610%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6010675390f6889e09a21e2c8b575b3ee25667ea8237a8d59423f73cb8c28610\", \"files\": {}}",
         "dest": "cargo/vendor/glyph_brush_draw_cache-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/glyph_brush_layout/glyph_brush_layout-0.2.3.crate",
         "sha256": "cc32c2334f00ca5ac3695c5009ae35da21da8c62d255b5b96d56e2597a637a38",
-        "dest": "cargo/vendor",
-        "dest-filename": "glyph_brush_layout-0.2.3.crate"
+        "dest": "cargo/vendor/glyph_brush_layout-0.2.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22cc32c2334f00ca5ac3695c5009ae35da21da8c62d255b5b96d56e2597a637a38%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"cc32c2334f00ca5ac3695c5009ae35da21da8c62d255b5b96d56e2597a637a38\", \"files\": {}}",
         "dest": "cargo/vendor/glyph_brush_layout-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/gpu-alloc/gpu-alloc-0.5.3.crate",
         "sha256": "7fc59e5f710e310e76e6707f86c561dd646f69a8876da9131703b2f717de818d",
-        "dest": "cargo/vendor",
-        "dest-filename": "gpu-alloc-0.5.3.crate"
+        "dest": "cargo/vendor/gpu-alloc-0.5.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227fc59e5f710e310e76e6707f86c561dd646f69a8876da9131703b2f717de818d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7fc59e5f710e310e76e6707f86c561dd646f69a8876da9131703b2f717de818d\", \"files\": {}}",
         "dest": "cargo/vendor/gpu-alloc-0.5.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/gpu-alloc-types/gpu-alloc-types-0.2.0.crate",
         "sha256": "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5",
-        "dest": "cargo/vendor",
-        "dest-filename": "gpu-alloc-types-0.2.0.crate"
+        "dest": "cargo/vendor/gpu-alloc-types-0.2.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2254804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5\", \"files\": {}}",
         "dest": "cargo/vendor/gpu-alloc-types-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/gpu-descriptor/gpu-descriptor-0.2.3.crate",
         "sha256": "0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a",
-        "dest": "cargo/vendor",
-        "dest-filename": "gpu-descriptor-0.2.3.crate"
+        "dest": "cargo/vendor/gpu-descriptor-0.2.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0b0c02e1ba0bdb14e965058ca34e09c020f8e507a760df1121728e0aef68d57a\", \"files\": {}}",
         "dest": "cargo/vendor/gpu-descriptor-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/gpu-descriptor-types/gpu-descriptor-types-0.1.1.crate",
         "sha256": "363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126",
-        "dest": "cargo/vendor",
-        "dest-filename": "gpu-descriptor-types-0.1.1.crate"
+        "dest": "cargo/vendor/gpu-descriptor-types-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"363e3677e55ad168fef68cf9de3a4a310b53124c5e784c53a1d70e92d23f2126\", \"files\": {}}",
         "dest": "cargo/vendor/gpu-descriptor-types-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/guillotiere/guillotiere-0.6.2.crate",
         "sha256": "b62d5865c036cb1393e23c50693df631d3f5d7bcca4c04fe4cc0fd592e74a782",
-        "dest": "cargo/vendor",
-        "dest-filename": "guillotiere-0.6.2.crate"
+        "dest": "cargo/vendor/guillotiere-0.6.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b62d5865c036cb1393e23c50693df631d3f5d7bcca4c04fe4cc0fd592e74a782%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b62d5865c036cb1393e23c50693df631d3f5d7bcca4c04fe4cc0fd592e74a782\", \"files\": {}}",
         "dest": "cargo/vendor/guillotiere-0.6.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/h2/h2-0.3.14.crate",
         "sha256": "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be",
-        "dest": "cargo/vendor",
-        "dest-filename": "h2-0.3.14.crate"
+        "dest": "cargo/vendor/h2-0.3.14"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be\", \"files\": {}}",
         "dest": "cargo/vendor/h2-0.3.14",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hashbrown/hashbrown-0.12.3.crate",
         "sha256": "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888",
-        "dest": "cargo/vendor",
-        "dest-filename": "hashbrown-0.12.3.crate"
+        "dest": "cargo/vendor/hashbrown-0.12.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888\", \"files\": {}}",
         "dest": "cargo/vendor/hashbrown-0.12.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/heck/heck-0.4.0.crate",
         "sha256": "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9",
-        "dest": "cargo/vendor",
-        "dest-filename": "heck-0.4.0.crate"
+        "dest": "cargo/vendor/heck-0.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9\", \"files\": {}}",
         "dest": "cargo/vendor/heck-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hermit-abi/hermit-abi-0.1.19.crate",
         "sha256": "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33",
-        "dest": "cargo/vendor",
-        "dest-filename": "hermit-abi-0.1.19.crate"
+        "dest": "cargo/vendor/hermit-abi-0.1.19"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2262b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33\", \"files\": {}}",
         "dest": "cargo/vendor/hermit-abi-0.1.19",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hex/hex-0.4.3.crate",
         "sha256": "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70",
-        "dest": "cargo/vendor",
-        "dest-filename": "hex-0.4.3.crate"
+        "dest": "cargo/vendor/hex-0.4.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70\", \"files\": {}}",
         "dest": "cargo/vendor/hex-0.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hexf-parse/hexf-parse-0.2.1.crate",
         "sha256": "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df",
-        "dest": "cargo/vendor",
-        "dest-filename": "hexf-parse-0.2.1.crate"
+        "dest": "cargo/vendor/hexf-parse-0.2.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df\", \"files\": {}}",
         "dest": "cargo/vendor/hexf-parse-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hkdf/hkdf-0.12.3.crate",
         "sha256": "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437",
-        "dest": "cargo/vendor",
-        "dest-filename": "hkdf-0.12.3.crate"
+        "dest": "cargo/vendor/hkdf-0.12.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437\", \"files\": {}}",
         "dest": "cargo/vendor/hkdf-0.12.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hmac/hmac-0.12.1.crate",
         "sha256": "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e",
-        "dest": "cargo/vendor",
-        "dest-filename": "hmac-0.12.1.crate"
+        "dest": "cargo/vendor/hmac-0.12.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e\", \"files\": {}}",
         "dest": "cargo/vendor/hmac-0.12.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/html2text/html2text-0.2.1.crate",
         "sha256": "a26379dcb715e237b96102a12b505c553e2bffa74bae2e54658748d298660ef1",
-        "dest": "cargo/vendor",
-        "dest-filename": "html2text-0.2.1.crate"
+        "dest": "cargo/vendor/html2text-0.2.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a26379dcb715e237b96102a12b505c553e2bffa74bae2e54658748d298660ef1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a26379dcb715e237b96102a12b505c553e2bffa74bae2e54658748d298660ef1\", \"files\": {}}",
         "dest": "cargo/vendor/html2text-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/html5ever/html5ever-0.25.2.crate",
         "sha256": "e5c13fb08e5d4dfc151ee5e88bae63f7773d61852f3bdc73c9f4b9e1bde03148",
-        "dest": "cargo/vendor",
-        "dest-filename": "html5ever-0.25.2.crate"
+        "dest": "cargo/vendor/html5ever-0.25.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e5c13fb08e5d4dfc151ee5e88bae63f7773d61852f3bdc73c9f4b9e1bde03148%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e5c13fb08e5d4dfc151ee5e88bae63f7773d61852f3bdc73c9f4b9e1bde03148\", \"files\": {}}",
         "dest": "cargo/vendor/html5ever-0.25.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/http/http-0.2.8.crate",
         "sha256": "75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399",
-        "dest": "cargo/vendor",
-        "dest-filename": "http-0.2.8.crate"
+        "dest": "cargo/vendor/http-0.2.8"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2275f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"75f43d41e26995c17e71ee126451dd3941010b0514a81a9d11f3b341debc2399\", \"files\": {}}",
         "dest": "cargo/vendor/http-0.2.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/http-body/http-body-0.4.5.crate",
         "sha256": "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1",
-        "dest": "cargo/vendor",
-        "dest-filename": "http-body-0.4.5.crate"
+        "dest": "cargo/vendor/http-body-0.4.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1\", \"files\": {}}",
         "dest": "cargo/vendor/http-body-0.4.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/httparse/httparse-1.8.0.crate",
         "sha256": "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904",
-        "dest": "cargo/vendor",
-        "dest-filename": "httparse-1.8.0.crate"
+        "dest": "cargo/vendor/httparse-1.8.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904\", \"files\": {}}",
         "dest": "cargo/vendor/httparse-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/httpdate/httpdate-1.0.2.crate",
         "sha256": "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421",
-        "dest": "cargo/vendor",
-        "dest-filename": "httpdate-1.0.2.crate"
+        "dest": "cargo/vendor/httpdate-1.0.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421\", \"files\": {}}",
         "dest": "cargo/vendor/httpdate-1.0.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hyper/hyper-0.14.20.crate",
         "sha256": "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac",
-        "dest": "cargo/vendor",
-        "dest-filename": "hyper-0.14.20.crate"
+        "dest": "cargo/vendor/hyper-0.14.20"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2202c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac\", \"files\": {}}",
         "dest": "cargo/vendor/hyper-0.14.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hyper-rustls/hyper-rustls-0.23.0.crate",
         "sha256": "d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac",
-        "dest": "cargo/vendor",
-        "dest-filename": "hyper-rustls-0.23.0.crate"
+        "dest": "cargo/vendor/hyper-rustls-0.23.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d87c48c02e0dc5e3b849a2041db3029fd066650f8f717c07bf8ed78ccb895cac\", \"files\": {}}",
         "dest": "cargo/vendor/hyper-rustls-0.23.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hyper-tls/hyper-tls-0.5.0.crate",
         "sha256": "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905",
-        "dest": "cargo/vendor",
-        "dest-filename": "hyper-tls-0.5.0.crate"
+        "dest": "cargo/vendor/hyper-tls-0.5.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905\", \"files\": {}}",
         "dest": "cargo/vendor/hyper-tls-0.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/hyperx/hyperx-1.4.0.crate",
         "sha256": "5617e92fc2f2501c3e2bc6ce547cad841adba2bae5b921c7e52510beca6d084c",
-        "dest": "cargo/vendor",
-        "dest-filename": "hyperx-1.4.0.crate"
+        "dest": "cargo/vendor/hyperx-1.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225617e92fc2f2501c3e2bc6ce547cad841adba2bae5b921c7e52510beca6d084c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5617e92fc2f2501c3e2bc6ce547cad841adba2bae5b921c7e52510beca6d084c\", \"files\": {}}",
         "dest": "cargo/vendor/hyperx-1.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/iana-time-zone/iana-time-zone-0.1.47.crate",
         "sha256": "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7",
-        "dest": "cargo/vendor",
-        "dest-filename": "iana-time-zone-0.1.47.crate"
+        "dest": "cargo/vendor/iana-time-zone-0.1.47"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7\", \"files\": {}}",
         "dest": "cargo/vendor/iana-time-zone-0.1.47",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/iced/iced-0.4.2.crate",
         "sha256": "6025abe6b1056c9b5adad79c484c5fd8b7012e5230f3b0439a1294ade7ded7bf",
-        "dest": "cargo/vendor",
-        "dest-filename": "iced-0.4.2.crate"
+        "dest": "cargo/vendor/iced-0.4.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226025abe6b1056c9b5adad79c484c5fd8b7012e5230f3b0439a1294ade7ded7bf%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6025abe6b1056c9b5adad79c484c5fd8b7012e5230f3b0439a1294ade7ded7bf\", \"files\": {}}",
         "dest": "cargo/vendor/iced-0.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/iced_core/iced_core-0.5.0.crate",
         "sha256": "ccf9133ceb345ec640047d5597fb8aa88e9cf74ce2d0277a9a62e2d6ed4a8148",
-        "dest": "cargo/vendor",
-        "dest-filename": "iced_core-0.5.0.crate"
+        "dest": "cargo/vendor/iced_core-0.5.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ccf9133ceb345ec640047d5597fb8aa88e9cf74ce2d0277a9a62e2d6ed4a8148%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ccf9133ceb345ec640047d5597fb8aa88e9cf74ce2d0277a9a62e2d6ed4a8148\", \"files\": {}}",
         "dest": "cargo/vendor/iced_core-0.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/iced_futures/iced_futures-0.4.1.crate",
         "sha256": "13d13241d5ed32846bbcffaf60e27e7ceebb60cf16d791ff00d582f0d4d1b07b",
-        "dest": "cargo/vendor",
-        "dest-filename": "iced_futures-0.4.1.crate"
+        "dest": "cargo/vendor/iced_futures-0.4.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2213d13241d5ed32846bbcffaf60e27e7ceebb60cf16d791ff00d582f0d4d1b07b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"13d13241d5ed32846bbcffaf60e27e7ceebb60cf16d791ff00d582f0d4d1b07b\", \"files\": {}}",
         "dest": "cargo/vendor/iced_futures-0.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/iced_graphics/iced_graphics-0.3.1.crate",
         "sha256": "2adcf703fc326e0985ea99c75f1b73e718560a7b220d57ec6478417ccb2f463f",
-        "dest": "cargo/vendor",
-        "dest-filename": "iced_graphics-0.3.1.crate"
+        "dest": "cargo/vendor/iced_graphics-0.3.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222adcf703fc326e0985ea99c75f1b73e718560a7b220d57ec6478417ccb2f463f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2adcf703fc326e0985ea99c75f1b73e718560a7b220d57ec6478417ccb2f463f\", \"files\": {}}",
         "dest": "cargo/vendor/iced_graphics-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/iced_lazy/iced_lazy-0.1.1.crate",
         "sha256": "333979d705964832864ee7676516ab3c3df4ab0b65efb603c86a256d4adbec6f",
-        "dest": "cargo/vendor",
-        "dest-filename": "iced_lazy-0.1.1.crate"
+        "dest": "cargo/vendor/iced_lazy-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22333979d705964832864ee7676516ab3c3df4ab0b65efb603c86a256d4adbec6f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"333979d705964832864ee7676516ab3c3df4ab0b65efb603c86a256d4adbec6f\", \"files\": {}}",
         "dest": "cargo/vendor/iced_lazy-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/iced_native/iced_native-0.5.1.crate",
         "sha256": "8ca174d4693a5daa2ffcae38d5c28cf0dbd54bd8fc19848f28392cd52624751a",
-        "dest": "cargo/vendor",
-        "dest-filename": "iced_native-0.5.1.crate"
+        "dest": "cargo/vendor/iced_native-0.5.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228ca174d4693a5daa2ffcae38d5c28cf0dbd54bd8fc19848f28392cd52624751a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8ca174d4693a5daa2ffcae38d5c28cf0dbd54bd8fc19848f28392cd52624751a\", \"files\": {}}",
         "dest": "cargo/vendor/iced_native-0.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/iced_pure/iced_pure-0.2.2.crate",
         "sha256": "80aeaecadfd6832c2c787cbdfd357adc256a51c55d68142d852037451e72f393",
-        "dest": "cargo/vendor",
-        "dest-filename": "iced_pure-0.2.2.crate"
+        "dest": "cargo/vendor/iced_pure-0.2.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2280aeaecadfd6832c2c787cbdfd357adc256a51c55d68142d852037451e72f393%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"80aeaecadfd6832c2c787cbdfd357adc256a51c55d68142d852037451e72f393\", \"files\": {}}",
         "dest": "cargo/vendor/iced_pure-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/iced_style/iced_style-0.4.0.crate",
         "sha256": "a90028c94ab62c13cd3b6fb1499a593a51510d4729c5b4e8e60705b2b28c6bc2",
-        "dest": "cargo/vendor",
-        "dest-filename": "iced_style-0.4.0.crate"
+        "dest": "cargo/vendor/iced_style-0.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a90028c94ab62c13cd3b6fb1499a593a51510d4729c5b4e8e60705b2b28c6bc2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a90028c94ab62c13cd3b6fb1499a593a51510d4729c5b4e8e60705b2b28c6bc2\", \"files\": {}}",
         "dest": "cargo/vendor/iced_style-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/iced_wgpu/iced_wgpu-0.5.1.crate",
         "sha256": "8bc44ca209f77bd855f035d2e86e50e66332f55fb60d9fb67eeb09eae9d9de2e",
-        "dest": "cargo/vendor",
-        "dest-filename": "iced_wgpu-0.5.1.crate"
+        "dest": "cargo/vendor/iced_wgpu-0.5.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228bc44ca209f77bd855f035d2e86e50e66332f55fb60d9fb67eeb09eae9d9de2e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8bc44ca209f77bd855f035d2e86e50e66332f55fb60d9fb67eeb09eae9d9de2e\", \"files\": {}}",
         "dest": "cargo/vendor/iced_wgpu-0.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/iced_winit/iced_winit-0.4.0.crate",
         "sha256": "72011b895e439e2ebad8f545720e3e97c7368ecfc47a23cbfeaa9508a98af90c",
-        "dest": "cargo/vendor",
-        "dest-filename": "iced_winit-0.4.0.crate"
+        "dest": "cargo/vendor/iced_winit-0.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2272011b895e439e2ebad8f545720e3e97c7368ecfc47a23cbfeaa9508a98af90c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"72011b895e439e2ebad8f545720e3e97c7368ecfc47a23cbfeaa9508a98af90c\", \"files\": {}}",
         "dest": "cargo/vendor/iced_winit-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ident_case/ident_case-1.0.1.crate",
         "sha256": "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39",
-        "dest": "cargo/vendor",
-        "dest-filename": "ident_case-1.0.1.crate"
+        "dest": "cargo/vendor/ident_case-1.0.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39\", \"files\": {}}",
         "dest": "cargo/vendor/ident_case-1.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/idna/idna-0.2.3.crate",
         "sha256": "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8",
-        "dest": "cargo/vendor",
-        "dest-filename": "idna-0.2.3.crate"
+        "dest": "cargo/vendor/idna-0.2.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8\", \"files\": {}}",
         "dest": "cargo/vendor/idna-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/image/image-0.23.14.crate",
         "sha256": "24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1",
-        "dest": "cargo/vendor",
-        "dest-filename": "image-0.23.14.crate"
+        "dest": "cargo/vendor/image-0.23.14"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2224ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"24ffcb7e7244a9bf19d35bf2883b9c080c4ced3c07a9895572178cdb8f13f6a1\", \"files\": {}}",
         "dest": "cargo/vendor/image-0.23.14",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/indexmap/indexmap-1.9.1.crate",
         "sha256": "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e",
-        "dest": "cargo/vendor",
-        "dest-filename": "indexmap-1.9.1.crate"
+        "dest": "cargo/vendor/indexmap-1.9.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2210a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e\", \"files\": {}}",
         "dest": "cargo/vendor/indexmap-1.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/indicatif/indicatif-0.15.0.crate",
         "sha256": "7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4",
-        "dest": "cargo/vendor",
-        "dest-filename": "indicatif-0.15.0.crate"
+        "dest": "cargo/vendor/indicatif-0.15.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7baab56125e25686df467fe470785512329883aab42696d661247aca2a2896e4\", \"files\": {}}",
         "dest": "cargo/vendor/indicatif-0.15.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/indicatif/indicatif-0.16.2.crate",
         "sha256": "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b",
-        "dest": "cargo/vendor",
-        "dest-filename": "indicatif-0.16.2.crate"
+        "dest": "cargo/vendor/indicatif-0.16.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b\", \"files\": {}}",
         "dest": "cargo/vendor/indicatif-0.16.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/inlinable_string/inlinable_string-0.1.15.crate",
         "sha256": "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb",
-        "dest": "cargo/vendor",
-        "dest-filename": "inlinable_string-0.1.15.crate"
+        "dest": "cargo/vendor/inlinable_string-0.1.15"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb\", \"files\": {}}",
         "dest": "cargo/vendor/inlinable_string-0.1.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/inplace_it/inplace_it-0.3.4.crate",
         "sha256": "67f0347836f3f6362c1e7efdadde2b1c4b4556d211310b70631bae7eb692070b",
-        "dest": "cargo/vendor",
-        "dest-filename": "inplace_it-0.3.4.crate"
+        "dest": "cargo/vendor/inplace_it-0.3.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2267f0347836f3f6362c1e7efdadde2b1c4b4556d211310b70631bae7eb692070b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"67f0347836f3f6362c1e7efdadde2b1c4b4556d211310b70631bae7eb692070b\", \"files\": {}}",
         "dest": "cargo/vendor/inplace_it-0.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/instant/instant-0.1.12.crate",
         "sha256": "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c",
-        "dest": "cargo/vendor",
-        "dest-filename": "instant-0.1.12.crate"
+        "dest": "cargo/vendor/instant-0.1.12"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c\", \"files\": {}}",
         "dest": "cargo/vendor/instant-0.1.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ipnet/ipnet-2.5.0.crate",
         "sha256": "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b",
-        "dest": "cargo/vendor",
-        "dest-filename": "ipnet-2.5.0.crate"
+        "dest": "cargo/vendor/ipnet-2.5.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b\", \"files\": {}}",
         "dest": "cargo/vendor/ipnet-2.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/itoa/itoa-1.0.3.crate",
         "sha256": "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754",
-        "dest": "cargo/vendor",
-        "dest-filename": "itoa-1.0.3.crate"
+        "dest": "cargo/vendor/itoa-1.0.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754\", \"files\": {}}",
         "dest": "cargo/vendor/itoa-1.0.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/jni-sys/jni-sys-0.3.0.crate",
         "sha256": "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130",
-        "dest": "cargo/vendor",
-        "dest-filename": "jni-sys-0.3.0.crate"
+        "dest": "cargo/vendor/jni-sys-0.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130\", \"files\": {}}",
         "dest": "cargo/vendor/jni-sys-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/jpeg-decoder/jpeg-decoder-0.1.22.crate",
         "sha256": "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2",
-        "dest": "cargo/vendor",
-        "dest-filename": "jpeg-decoder-0.1.22.crate"
+        "dest": "cargo/vendor/jpeg-decoder-0.1.22"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2\", \"files\": {}}",
         "dest": "cargo/vendor/jpeg-decoder-0.1.22",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/js-sys/js-sys-0.3.59.crate",
         "sha256": "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2",
-        "dest": "cargo/vendor",
-        "dest-filename": "js-sys-0.3.59.crate"
+        "dest": "cargo/vendor/js-sys-0.3.59"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2\", \"files\": {}}",
         "dest": "cargo/vendor/js-sys-0.3.59",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/jsonwebtoken/jsonwebtoken-7.2.0.crate",
         "sha256": "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32",
-        "dest": "cargo/vendor",
-        "dest-filename": "jsonwebtoken-7.2.0.crate"
+        "dest": "cargo/vendor/jsonwebtoken-7.2.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32\", \"files\": {}}",
         "dest": "cargo/vendor/jsonwebtoken-7.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/kamadak-exif/kamadak-exif-0.5.4.crate",
         "sha256": "70494964492bf8e491eb3951c5d70c9627eb7100ede6cc56d748b9a3f302cfb6",
-        "dest": "cargo/vendor",
-        "dest-filename": "kamadak-exif-0.5.4.crate"
+        "dest": "cargo/vendor/kamadak-exif-0.5.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2270494964492bf8e491eb3951c5d70c9627eb7100ede6cc56d748b9a3f302cfb6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"70494964492bf8e491eb3951c5d70c9627eb7100ede6cc56d748b9a3f302cfb6\", \"files\": {}}",
         "dest": "cargo/vendor/kamadak-exif-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/khronos-egl/khronos-egl-4.1.0.crate",
         "sha256": "8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3",
-        "dest": "cargo/vendor",
-        "dest-filename": "khronos-egl-4.1.0.crate"
+        "dest": "cargo/vendor/khronos-egl-4.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8c2352bd1d0bceb871cb9d40f24360c8133c11d7486b68b5381c1dd1a32015e3\", \"files\": {}}",
         "dest": "cargo/vendor/khronos-egl-4.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/language-tags/language-tags-0.3.2.crate",
         "sha256": "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388",
-        "dest": "cargo/vendor",
-        "dest-filename": "language-tags-0.3.2.crate"
+        "dest": "cargo/vendor/language-tags-0.3.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388\", \"files\": {}}",
         "dest": "cargo/vendor/language-tags-0.3.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/lazy_static/lazy_static-1.4.0.crate",
         "sha256": "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646",
-        "dest": "cargo/vendor",
-        "dest-filename": "lazy_static-1.4.0.crate"
+        "dest": "cargo/vendor/lazy_static-1.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646\", \"files\": {}}",
         "dest": "cargo/vendor/lazy_static-1.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/libc/libc-0.2.132.crate",
         "sha256": "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5",
-        "dest": "cargo/vendor",
-        "dest-filename": "libc-0.2.132.crate"
+        "dest": "cargo/vendor/libc-0.2.132"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5\", \"files\": {}}",
         "dest": "cargo/vendor/libc-0.2.132",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/libloading/libloading-0.7.3.crate",
         "sha256": "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd",
-        "dest": "cargo/vendor",
-        "dest-filename": "libloading-0.7.3.crate"
+        "dest": "cargo/vendor/libloading-0.7.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd\", \"files\": {}}",
         "dest": "cargo/vendor/libloading-0.7.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/libsqlite3-sys/libsqlite3-sys-0.22.2.crate",
         "sha256": "290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d",
-        "dest": "cargo/vendor",
-        "dest-filename": "libsqlite3-sys-0.22.2.crate"
+        "dest": "cargo/vendor/libsqlite3-sys-0.22.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"290b64917f8b0cb885d9de0f9959fe1f775d7fa12f1da2db9001c1c8ab60f89d\", \"files\": {}}",
         "dest": "cargo/vendor/libsqlite3-sys-0.22.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/linked-hash-map/linked-hash-map-0.5.6.crate",
         "sha256": "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f",
-        "dest": "cargo/vendor",
-        "dest-filename": "linked-hash-map-0.5.6.crate"
+        "dest": "cargo/vendor/linked-hash-map-0.5.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f\", \"files\": {}}",
         "dest": "cargo/vendor/linked-hash-map-0.5.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/lock_api/lock_api-0.4.8.crate",
         "sha256": "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390",
-        "dest": "cargo/vendor",
-        "dest-filename": "lock_api-0.4.8.crate"
+        "dest": "cargo/vendor/lock_api-0.4.8"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390\", \"files\": {}}",
         "dest": "cargo/vendor/lock_api-0.4.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/log/log-0.4.17.crate",
         "sha256": "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e",
-        "dest": "cargo/vendor",
-        "dest-filename": "log-0.4.17.crate"
+        "dest": "cargo/vendor/log-0.4.17"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e\", \"files\": {}}",
         "dest": "cargo/vendor/log-0.4.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/loom/loom-0.5.6.crate",
         "sha256": "ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5",
-        "dest": "cargo/vendor",
-        "dest-filename": "loom-0.5.6.crate"
+        "dest": "cargo/vendor/loom-0.5.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ff50ecb28bb86013e935fb6683ab1f6d3a20016f123c76fd4c27470076ac30f5\", \"files\": {}}",
         "dest": "cargo/vendor/loom-0.5.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/mac/mac-0.1.1.crate",
         "sha256": "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4",
-        "dest": "cargo/vendor",
-        "dest-filename": "mac-0.1.1.crate"
+        "dest": "cargo/vendor/mac-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4\", \"files\": {}}",
         "dest": "cargo/vendor/mac-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/malloc_buf/malloc_buf-0.0.6.crate",
         "sha256": "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb",
-        "dest": "cargo/vendor",
-        "dest-filename": "malloc_buf-0.0.6.crate"
+        "dest": "cargo/vendor/malloc_buf-0.0.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2262bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb\", \"files\": {}}",
         "dest": "cargo/vendor/malloc_buf-0.0.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/markup5ever/markup5ever-0.10.1.crate",
         "sha256": "a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd",
-        "dest": "cargo/vendor",
-        "dest-filename": "markup5ever-0.10.1.crate"
+        "dest": "cargo/vendor/markup5ever-0.10.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a24f40fb03852d1cdd84330cddcaf98e9ec08a7b7768e952fad3b4cf048ec8fd\", \"files\": {}}",
         "dest": "cargo/vendor/markup5ever-0.10.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/markup5ever_rcdom/markup5ever_rcdom-0.1.0.crate",
         "sha256": "f015da43bcd8d4f144559a3423f4591d69b8ce0652c905374da7205df336ae2b",
-        "dest": "cargo/vendor",
-        "dest-filename": "markup5ever_rcdom-0.1.0.crate"
+        "dest": "cargo/vendor/markup5ever_rcdom-0.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f015da43bcd8d4f144559a3423f4591d69b8ce0652c905374da7205df336ae2b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f015da43bcd8d4f144559a3423f4591d69b8ce0652c905374da7205df336ae2b\", \"files\": {}}",
         "dest": "cargo/vendor/markup5ever_rcdom-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/matchers/matchers-0.1.0.crate",
         "sha256": "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558",
-        "dest": "cargo/vendor",
-        "dest-filename": "matchers-0.1.0.crate"
+        "dest": "cargo/vendor/matchers-0.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558\", \"files\": {}}",
         "dest": "cargo/vendor/matchers-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/matches/matches-0.1.9.crate",
         "sha256": "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f",
-        "dest": "cargo/vendor",
-        "dest-filename": "matches-0.1.9.crate"
+        "dest": "cargo/vendor/matches-0.1.9"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f\", \"files\": {}}",
         "dest": "cargo/vendor/matches-0.1.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/md5/md5-0.7.0.crate",
         "sha256": "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771",
-        "dest": "cargo/vendor",
-        "dest-filename": "md5-0.7.0.crate"
+        "dest": "cargo/vendor/md5-0.7.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771\", \"files\": {}}",
         "dest": "cargo/vendor/md5-0.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/memchr/memchr-2.5.0.crate",
         "sha256": "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d",
-        "dest": "cargo/vendor",
-        "dest-filename": "memchr-2.5.0.crate"
+        "dest": "cargo/vendor/memchr-2.5.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d\", \"files\": {}}",
         "dest": "cargo/vendor/memchr-2.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/memmap2/memmap2-0.3.1.crate",
         "sha256": "00b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357",
-        "dest": "cargo/vendor",
-        "dest-filename": "memmap2-0.3.1.crate"
+        "dest": "cargo/vendor/memmap2-0.3.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2200b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"00b6c2ebff6180198788f5db08d7ce3bc1d0b617176678831a7510825973e357\", \"files\": {}}",
         "dest": "cargo/vendor/memmap2-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/memmap2/memmap2-0.5.7.crate",
         "sha256": "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498",
-        "dest": "cargo/vendor",
-        "dest-filename": "memmap2-0.5.7.crate"
+        "dest": "cargo/vendor/memmap2-0.5.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2295af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498\", \"files\": {}}",
         "dest": "cargo/vendor/memmap2-0.5.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/memoffset/memoffset-0.6.5.crate",
         "sha256": "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce",
-        "dest": "cargo/vendor",
-        "dest-filename": "memoffset-0.6.5.crate"
+        "dest": "cargo/vendor/memoffset-0.6.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce\", \"files\": {}}",
         "dest": "cargo/vendor/memoffset-0.6.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/metal/metal-0.23.1.crate",
         "sha256": "e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084",
-        "dest": "cargo/vendor",
-        "dest-filename": "metal-0.23.1.crate"
+        "dest": "cargo/vendor/metal-0.23.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e0514f491f4cc03632ab399ee01e2c1c1b12d3e1cf2d667c1ff5f87d6dcd2084\", \"files\": {}}",
         "dest": "cargo/vendor/metal-0.23.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/migrations_internals/migrations_internals-1.4.1.crate",
         "sha256": "2b4fc84e4af020b837029e017966f86a1c2d5e83e64b589963d5047525995860",
-        "dest": "cargo/vendor",
-        "dest-filename": "migrations_internals-1.4.1.crate"
+        "dest": "cargo/vendor/migrations_internals-1.4.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222b4fc84e4af020b837029e017966f86a1c2d5e83e64b589963d5047525995860%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2b4fc84e4af020b837029e017966f86a1c2d5e83e64b589963d5047525995860\", \"files\": {}}",
         "dest": "cargo/vendor/migrations_internals-1.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/migrations_macros/migrations_macros-1.4.2.crate",
         "sha256": "9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c",
-        "dest": "cargo/vendor",
-        "dest-filename": "migrations_macros-1.4.2.crate"
+        "dest": "cargo/vendor/migrations_macros-1.4.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9753f12909fd8d923f75ae5c3258cae1ed3c8ec052e1b38c93c21a6d157f789c\", \"files\": {}}",
         "dest": "cargo/vendor/migrations_macros-1.4.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/mime/mime-0.3.16.crate",
         "sha256": "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d",
-        "dest": "cargo/vendor",
-        "dest-filename": "mime-0.3.16.crate"
+        "dest": "cargo/vendor/mime-0.3.16"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d\", \"files\": {}}",
         "dest": "cargo/vendor/mime-0.3.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/minimal-lexical/minimal-lexical-0.2.1.crate",
         "sha256": "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a",
-        "dest": "cargo/vendor",
-        "dest-filename": "minimal-lexical-0.2.1.crate"
+        "dest": "cargo/vendor/minimal-lexical-0.2.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2268354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a\", \"files\": {}}",
         "dest": "cargo/vendor/minimal-lexical-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.3.7.crate",
         "sha256": "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435",
-        "dest": "cargo/vendor",
-        "dest-filename": "miniz_oxide-0.3.7.crate"
+        "dest": "cargo/vendor/miniz_oxide-0.3.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435\", \"files\": {}}",
         "dest": "cargo/vendor/miniz_oxide-0.3.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/miniz_oxide/miniz_oxide-0.5.4.crate",
         "sha256": "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34",
-        "dest": "cargo/vendor",
-        "dest-filename": "miniz_oxide-0.5.4.crate"
+        "dest": "cargo/vendor/miniz_oxide-0.5.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2296590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34\", \"files\": {}}",
         "dest": "cargo/vendor/miniz_oxide-0.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/mio/mio-0.8.4.crate",
         "sha256": "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf",
-        "dest": "cargo/vendor",
-        "dest-filename": "mio-0.8.4.crate"
+        "dest": "cargo/vendor/mio-0.8.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2257ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf\", \"files\": {}}",
         "dest": "cargo/vendor/mio-0.8.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/multer/multer-2.0.3.crate",
         "sha256": "a30ba6d97eb198c5e8a35d67d5779d6680cca35652a60ee90fc23dc431d4fde8",
-        "dest": "cargo/vendor",
-        "dest-filename": "multer-2.0.3.crate"
+        "dest": "cargo/vendor/multer-2.0.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a30ba6d97eb198c5e8a35d67d5779d6680cca35652a60ee90fc23dc431d4fde8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a30ba6d97eb198c5e8a35d67d5779d6680cca35652a60ee90fc23dc431d4fde8\", \"files\": {}}",
         "dest": "cargo/vendor/multer-2.0.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/mutate_once/mutate_once-0.1.1.crate",
         "sha256": "16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b",
-        "dest": "cargo/vendor",
-        "dest-filename": "mutate_once-0.1.1.crate"
+        "dest": "cargo/vendor/mutate_once-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2216cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"16cf681a23b4d0a43fc35024c176437f9dcd818db34e0f42ab456a0ee5ad497b\", \"files\": {}}",
         "dest": "cargo/vendor/mutate_once-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/naga/naga-0.8.5.crate",
         "sha256": "3012f2dbcc79e8e0b5825a4836a7106a75dd9b2fe42c528163be0f572538c705",
-        "dest": "cargo/vendor",
-        "dest-filename": "naga-0.8.5.crate"
+        "dest": "cargo/vendor/naga-0.8.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223012f2dbcc79e8e0b5825a4836a7106a75dd9b2fe42c528163be0f572538c705%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3012f2dbcc79e8e0b5825a4836a7106a75dd9b2fe42c528163be0f572538c705\", \"files\": {}}",
         "dest": "cargo/vendor/naga-0.8.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/native-tls/native-tls-0.2.10.crate",
         "sha256": "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9",
-        "dest": "cargo/vendor",
-        "dest-filename": "native-tls-0.2.10.crate"
+        "dest": "cargo/vendor/native-tls-0.2.10"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9\", \"files\": {}}",
         "dest": "cargo/vendor/native-tls-0.2.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ndk/ndk-0.5.0.crate",
         "sha256": "96d868f654c72e75f8687572699cdabe755f03effbb62542768e995d5b8d699d",
-        "dest": "cargo/vendor",
-        "dest-filename": "ndk-0.5.0.crate"
+        "dest": "cargo/vendor/ndk-0.5.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2296d868f654c72e75f8687572699cdabe755f03effbb62542768e995d5b8d699d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"96d868f654c72e75f8687572699cdabe755f03effbb62542768e995d5b8d699d\", \"files\": {}}",
         "dest": "cargo/vendor/ndk-0.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ndk-context/ndk-context-0.1.1.crate",
         "sha256": "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b",
-        "dest": "cargo/vendor",
-        "dest-filename": "ndk-context-0.1.1.crate"
+        "dest": "cargo/vendor/ndk-context-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2227b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b\", \"files\": {}}",
         "dest": "cargo/vendor/ndk-context-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ndk-glue/ndk-glue-0.5.2.crate",
         "sha256": "c71bee8ea72d685477e28bd004cfe1bf99c754d688cd78cad139eae4089484d4",
-        "dest": "cargo/vendor",
-        "dest-filename": "ndk-glue-0.5.2.crate"
+        "dest": "cargo/vendor/ndk-glue-0.5.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c71bee8ea72d685477e28bd004cfe1bf99c754d688cd78cad139eae4089484d4%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c71bee8ea72d685477e28bd004cfe1bf99c754d688cd78cad139eae4089484d4\", \"files\": {}}",
         "dest": "cargo/vendor/ndk-glue-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ndk-macro/ndk-macro-0.3.0.crate",
         "sha256": "0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c",
-        "dest": "cargo/vendor",
-        "dest-filename": "ndk-macro-0.3.0.crate"
+        "dest": "cargo/vendor/ndk-macro-0.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0df7ac00c4672f9d5aece54ee3347520b7e20f158656c7db2e6de01902eb7a6c\", \"files\": {}}",
         "dest": "cargo/vendor/ndk-macro-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ndk-sys/ndk-sys-0.2.2.crate",
         "sha256": "e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121",
-        "dest": "cargo/vendor",
-        "dest-filename": "ndk-sys-0.2.2.crate"
+        "dest": "cargo/vendor/ndk-sys-0.2.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e1bcdd74c20ad5d95aacd60ef9ba40fdf77f767051040541df557b7a9b2a2121\", \"files\": {}}",
         "dest": "cargo/vendor/ndk-sys-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/new_debug_unreachable/new_debug_unreachable-1.0.4.crate",
         "sha256": "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54",
-        "dest": "cargo/vendor",
-        "dest-filename": "new_debug_unreachable-1.0.4.crate"
+        "dest": "cargo/vendor/new_debug_unreachable-1.0.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54\", \"files\": {}}",
         "dest": "cargo/vendor/new_debug_unreachable-1.0.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/nix/nix-0.22.3.crate",
         "sha256": "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf",
-        "dest": "cargo/vendor",
-        "dest-filename": "nix-0.22.3.crate"
+        "dest": "cargo/vendor/nix-0.22.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf\", \"files\": {}}",
         "dest": "cargo/vendor/nix-0.22.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/nix/nix-0.24.2.crate",
         "sha256": "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc",
-        "dest": "cargo/vendor",
-        "dest-filename": "nix-0.24.2.crate"
+        "dest": "cargo/vendor/nix-0.24.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc\", \"files\": {}}",
         "dest": "cargo/vendor/nix-0.24.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/no-std-net/no-std-net-0.6.0.crate",
         "sha256": "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65",
-        "dest": "cargo/vendor",
-        "dest-filename": "no-std-net-0.6.0.crate"
+        "dest": "cargo/vendor/no-std-net-0.6.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2243794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65\", \"files\": {}}",
         "dest": "cargo/vendor/no-std-net-0.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/nom/nom-7.1.1.crate",
         "sha256": "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36",
-        "dest": "cargo/vendor",
-        "dest-filename": "nom-7.1.1.crate"
+        "dest": "cargo/vendor/nom-7.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36\", \"files\": {}}",
         "dest": "cargo/vendor/nom-7.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/num-bigint/num-bigint-0.2.6.crate",
         "sha256": "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304",
-        "dest": "cargo/vendor",
-        "dest-filename": "num-bigint-0.2.6.crate"
+        "dest": "cargo/vendor/num-bigint-0.2.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304\", \"files\": {}}",
         "dest": "cargo/vendor/num-bigint-0.2.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/num-integer/num-integer-0.1.45.crate",
         "sha256": "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9",
-        "dest": "cargo/vendor",
-        "dest-filename": "num-integer-0.1.45.crate"
+        "dest": "cargo/vendor/num-integer-0.1.45"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9\", \"files\": {}}",
         "dest": "cargo/vendor/num-integer-0.1.45",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/num-iter/num-iter-0.1.43.crate",
         "sha256": "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252",
-        "dest": "cargo/vendor",
-        "dest-filename": "num-iter-0.1.43.crate"
+        "dest": "cargo/vendor/num-iter-0.1.43"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252\", \"files\": {}}",
         "dest": "cargo/vendor/num-iter-0.1.43",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/num-rational/num-rational-0.3.2.crate",
         "sha256": "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07",
-        "dest": "cargo/vendor",
-        "dest-filename": "num-rational-0.3.2.crate"
+        "dest": "cargo/vendor/num-rational-0.3.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2212ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07\", \"files\": {}}",
         "dest": "cargo/vendor/num-rational-0.3.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/num-traits/num-traits-0.2.15.crate",
         "sha256": "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd",
-        "dest": "cargo/vendor",
-        "dest-filename": "num-traits-0.2.15.crate"
+        "dest": "cargo/vendor/num-traits-0.2.15"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd\", \"files\": {}}",
         "dest": "cargo/vendor/num-traits-0.2.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/num_cpus/num_cpus-1.13.1.crate",
         "sha256": "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1",
-        "dest": "cargo/vendor",
-        "dest-filename": "num_cpus-1.13.1.crate"
+        "dest": "cargo/vendor/num_cpus-1.13.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2219e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1\", \"files\": {}}",
         "dest": "cargo/vendor/num_cpus-1.13.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/num_enum/num_enum-0.5.7.crate",
         "sha256": "cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9",
-        "dest": "cargo/vendor",
-        "dest-filename": "num_enum-0.5.7.crate"
+        "dest": "cargo/vendor/num_enum-0.5.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"cf5395665662ef45796a4ff5486c5d41d29e0c09640af4c5f17fd94ee2c119c9\", \"files\": {}}",
         "dest": "cargo/vendor/num_enum-0.5.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/num_enum_derive/num_enum_derive-0.5.7.crate",
         "sha256": "3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce",
-        "dest": "cargo/vendor",
-        "dest-filename": "num_enum_derive-0.5.7.crate"
+        "dest": "cargo/vendor/num_enum_derive-0.5.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3b0498641e53dd6ac1a4f22547548caa6864cc4933784319cd1775271c5a46ce\", \"files\": {}}",
         "dest": "cargo/vendor/num_enum_derive-0.5.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/num_threads/num_threads-0.1.6.crate",
         "sha256": "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44",
-        "dest": "cargo/vendor",
-        "dest-filename": "num_threads-0.1.6.crate"
+        "dest": "cargo/vendor/num_threads-0.1.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44\", \"files\": {}}",
         "dest": "cargo/vendor/num_threads-0.1.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/number_prefix/number_prefix-0.3.0.crate",
         "sha256": "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a",
-        "dest": "cargo/vendor",
-        "dest-filename": "number_prefix-0.3.0.crate"
+        "dest": "cargo/vendor/number_prefix-0.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2217b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a\", \"files\": {}}",
         "dest": "cargo/vendor/number_prefix-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/number_prefix/number_prefix-0.4.0.crate",
         "sha256": "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3",
-        "dest": "cargo/vendor",
-        "dest-filename": "number_prefix-0.4.0.crate"
+        "dest": "cargo/vendor/number_prefix-0.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3\", \"files\": {}}",
         "dest": "cargo/vendor/number_prefix-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/objc/objc-0.2.7.crate",
         "sha256": "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1",
-        "dest": "cargo/vendor",
-        "dest-filename": "objc-0.2.7.crate"
+        "dest": "cargo/vendor/objc-0.2.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1\", \"files\": {}}",
         "dest": "cargo/vendor/objc-0.2.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/objc-foundation/objc-foundation-0.1.1.crate",
         "sha256": "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9",
-        "dest": "cargo/vendor",
-        "dest-filename": "objc-foundation-0.1.1.crate"
+        "dest": "cargo/vendor/objc-foundation-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%221add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9\", \"files\": {}}",
         "dest": "cargo/vendor/objc-foundation-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/objc_exception/objc_exception-0.1.2.crate",
         "sha256": "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4",
-        "dest": "cargo/vendor",
-        "dest-filename": "objc_exception-0.1.2.crate"
+        "dest": "cargo/vendor/objc_exception-0.1.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4\", \"files\": {}}",
         "dest": "cargo/vendor/objc_exception-0.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/objc_id/objc_id-0.1.1.crate",
         "sha256": "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b",
-        "dest": "cargo/vendor",
-        "dest-filename": "objc_id-0.1.1.crate"
+        "dest": "cargo/vendor/objc_id-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b\", \"files\": {}}",
         "dest": "cargo/vendor/objc_id-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/object/object-0.29.0.crate",
         "sha256": "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53",
-        "dest": "cargo/vendor",
-        "dest-filename": "object-0.29.0.crate"
+        "dest": "cargo/vendor/object-0.29.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2221158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53\", \"files\": {}}",
         "dest": "cargo/vendor/object-0.29.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "git",
-        "url": "https://github.com/xampprocky/octocrab",
-        "commit": "c78edcd87fa5edcd5a6d0d0878b2a8d020802c40",
-        "dest": "cargo/vendor/octocrab"
+        "type": "shell",
+        "commands": [
+            "cp -r --reflink=auto \"flatpak-cargo/git/octocrab-c78edcd/.\" \"cargo/vendor/octocrab\""
+        ]
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20null%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": null, \"files\": {}}",
         "dest": "cargo/vendor/octocrab",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/once_cell/once_cell-1.14.0.crate",
         "sha256": "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0",
-        "dest": "cargo/vendor",
-        "dest-filename": "once_cell-1.14.0.crate"
+        "dest": "cargo/vendor/once_cell-1.14.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0\", \"files\": {}}",
         "dest": "cargo/vendor/once_cell-1.14.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/opaque-debug/opaque-debug-0.3.0.crate",
         "sha256": "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5",
-        "dest": "cargo/vendor",
-        "dest-filename": "opaque-debug-0.3.0.crate"
+        "dest": "cargo/vendor/opaque-debug-0.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5\", \"files\": {}}",
         "dest": "cargo/vendor/opaque-debug-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/opener/opener-0.5.0.crate",
         "sha256": "4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952",
-        "dest": "cargo/vendor",
-        "dest-filename": "opener-0.5.0.crate"
+        "dest": "cargo/vendor/opener-0.5.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4ea3ebcd72a54701f56345f16785a6d3ac2df7e986d273eb4395c0b01db17952\", \"files\": {}}",
         "dest": "cargo/vendor/opener-0.5.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/openssl/openssl-0.10.41.crate",
         "sha256": "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0",
-        "dest": "cargo/vendor",
-        "dest-filename": "openssl-0.10.41.crate"
+        "dest": "cargo/vendor/openssl-0.10.41"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0\", \"files\": {}}",
         "dest": "cargo/vendor/openssl-0.10.41",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/openssl-macros/openssl-macros-0.1.0.crate",
         "sha256": "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c",
-        "dest": "cargo/vendor",
-        "dest-filename": "openssl-macros-0.1.0.crate"
+        "dest": "cargo/vendor/openssl-macros-0.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c\", \"files\": {}}",
         "dest": "cargo/vendor/openssl-macros-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/openssl-probe/openssl-probe-0.1.5.crate",
         "sha256": "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf",
-        "dest": "cargo/vendor",
-        "dest-filename": "openssl-probe-0.1.5.crate"
+        "dest": "cargo/vendor/openssl-probe-0.1.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf\", \"files\": {}}",
         "dest": "cargo/vendor/openssl-probe-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/openssl-src/openssl-src-111.22.0+1.1.1q.crate",
         "sha256": "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853",
-        "dest": "cargo/vendor",
-        "dest-filename": "openssl-src-111.22.0+1.1.1q.crate"
+        "dest": "cargo/vendor/openssl-src-111.22.0+1.1.1q"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853\", \"files\": {}}",
         "dest": "cargo/vendor/openssl-src-111.22.0+1.1.1q",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/openssl-sys/openssl-sys-0.9.75.crate",
         "sha256": "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f",
-        "dest": "cargo/vendor",
-        "dest-filename": "openssl-sys-0.9.75.crate"
+        "dest": "cargo/vendor/openssl-sys-0.9.75"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f\", \"files\": {}}",
         "dest": "cargo/vendor/openssl-sys-0.9.75",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ordered-float/ordered-float-3.0.0.crate",
         "sha256": "96bcbab4bfea7a59c2c0fe47211a1ac4e3e96bea6eb446d704f310bc5c732ae2",
-        "dest": "cargo/vendor",
-        "dest-filename": "ordered-float-3.0.0.crate"
+        "dest": "cargo/vendor/ordered-float-3.0.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2296bcbab4bfea7a59c2c0fe47211a1ac4e3e96bea6eb446d704f310bc5c732ae2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"96bcbab4bfea7a59c2c0fe47211a1ac4e3e96bea6eb446d704f310bc5c732ae2\", \"files\": {}}",
         "dest": "cargo/vendor/ordered-float-3.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/os_str_bytes/os_str_bytes-6.3.0.crate",
         "sha256": "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff",
-        "dest": "cargo/vendor",
-        "dest-filename": "os_str_bytes-6.3.0.crate"
+        "dest": "cargo/vendor/os_str_bytes-6.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff\", \"files\": {}}",
         "dest": "cargo/vendor/os_str_bytes-6.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ouroboros/ouroboros-0.13.0.crate",
         "sha256": "f357ef82d1b4db66fbed0b8d542cbd3c22d0bf5b393b3c257b9ba4568e70c9c3",
-        "dest": "cargo/vendor",
-        "dest-filename": "ouroboros-0.13.0.crate"
+        "dest": "cargo/vendor/ouroboros-0.13.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f357ef82d1b4db66fbed0b8d542cbd3c22d0bf5b393b3c257b9ba4568e70c9c3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f357ef82d1b4db66fbed0b8d542cbd3c22d0bf5b393b3c257b9ba4568e70c9c3\", \"files\": {}}",
         "dest": "cargo/vendor/ouroboros-0.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ouroboros_macro/ouroboros_macro-0.13.0.crate",
         "sha256": "44a0b52c2cbaef7dffa5fec1a43274afe8bd2a644fa9fc50a9ef4ff0269b1257",
-        "dest": "cargo/vendor",
-        "dest-filename": "ouroboros_macro-0.13.0.crate"
+        "dest": "cargo/vendor/ouroboros_macro-0.13.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2244a0b52c2cbaef7dffa5fec1a43274afe8bd2a644fa9fc50a9ef4ff0269b1257%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"44a0b52c2cbaef7dffa5fec1a43274afe8bd2a644fa9fc50a9ef4ff0269b1257\", \"files\": {}}",
         "dest": "cargo/vendor/ouroboros_macro-0.13.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/owned_ttf_parser/owned_ttf_parser-0.15.2.crate",
         "sha256": "05e6affeb1632d6ff6a23d2cd40ffed138e82f1532571a26f527c8a284bb2fbb",
-        "dest": "cargo/vendor",
-        "dest-filename": "owned_ttf_parser-0.15.2.crate"
+        "dest": "cargo/vendor/owned_ttf_parser-0.15.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2205e6affeb1632d6ff6a23d2cd40ffed138e82f1532571a26f527c8a284bb2fbb%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"05e6affeb1632d6ff6a23d2cd40ffed138e82f1532571a26f527c8a284bb2fbb\", \"files\": {}}",
         "dest": "cargo/vendor/owned_ttf_parser-0.15.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/parking_lot/parking_lot-0.11.2.crate",
         "sha256": "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99",
-        "dest": "cargo/vendor",
-        "dest-filename": "parking_lot-0.11.2.crate"
+        "dest": "cargo/vendor/parking_lot-0.11.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99\", \"files\": {}}",
         "dest": "cargo/vendor/parking_lot-0.11.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/parking_lot/parking_lot-0.12.1.crate",
         "sha256": "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f",
-        "dest": "cargo/vendor",
-        "dest-filename": "parking_lot-0.12.1.crate"
+        "dest": "cargo/vendor/parking_lot-0.12.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f\", \"files\": {}}",
         "dest": "cargo/vendor/parking_lot-0.12.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.8.5.crate",
         "sha256": "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216",
-        "dest": "cargo/vendor",
-        "dest-filename": "parking_lot_core-0.8.5.crate"
+        "dest": "cargo/vendor/parking_lot_core-0.8.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216\", \"files\": {}}",
         "dest": "cargo/vendor/parking_lot_core-0.8.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/parking_lot_core/parking_lot_core-0.9.3.crate",
         "sha256": "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929",
-        "dest": "cargo/vendor",
-        "dest-filename": "parking_lot_core-0.9.3.crate"
+        "dest": "cargo/vendor/parking_lot_core-0.9.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2209a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929\", \"files\": {}}",
         "dest": "cargo/vendor/parking_lot_core-0.9.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pear/pear-0.2.3.crate",
         "sha256": "15e44241c5e4c868e3eaa78b7c1848cadd6344ed4f54d029832d32b415a58702",
-        "dest": "cargo/vendor",
-        "dest-filename": "pear-0.2.3.crate"
+        "dest": "cargo/vendor/pear-0.2.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2215e44241c5e4c868e3eaa78b7c1848cadd6344ed4f54d029832d32b415a58702%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"15e44241c5e4c868e3eaa78b7c1848cadd6344ed4f54d029832d32b415a58702\", \"files\": {}}",
         "dest": "cargo/vendor/pear-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pear_codegen/pear_codegen-0.2.3.crate",
         "sha256": "82a5ca643c2303ecb740d506539deba189e16f2754040a42901cd8105d0282d0",
-        "dest": "cargo/vendor",
-        "dest-filename": "pear_codegen-0.2.3.crate"
+        "dest": "cargo/vendor/pear_codegen-0.2.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2282a5ca643c2303ecb740d506539deba189e16f2754040a42901cd8105d0282d0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"82a5ca643c2303ecb740d506539deba189e16f2754040a42901cd8105d0282d0\", \"files\": {}}",
         "dest": "cargo/vendor/pear_codegen-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pem/pem-0.8.3.crate",
         "sha256": "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb",
-        "dest": "cargo/vendor",
-        "dest-filename": "pem-0.8.3.crate"
+        "dest": "cargo/vendor/pem-0.8.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb\", \"files\": {}}",
         "dest": "cargo/vendor/pem-0.8.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/percent-encoding/percent-encoding-2.1.0.crate",
         "sha256": "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e",
-        "dest": "cargo/vendor",
-        "dest-filename": "percent-encoding-2.1.0.crate"
+        "dest": "cargo/vendor/percent-encoding-2.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e\", \"files\": {}}",
         "dest": "cargo/vendor/percent-encoding-2.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pest/pest-2.3.0.crate",
         "sha256": "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4",
-        "dest": "cargo/vendor",
-        "dest-filename": "pest-2.3.0.crate"
+        "dest": "cargo/vendor/pest-2.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4\", \"files\": {}}",
         "dest": "cargo/vendor/pest-2.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/phf/phf-0.8.0.crate",
         "sha256": "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12",
-        "dest": "cargo/vendor",
-        "dest-filename": "phf-0.8.0.crate"
+        "dest": "cargo/vendor/phf-0.8.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12\", \"files\": {}}",
         "dest": "cargo/vendor/phf-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/phf_codegen/phf_codegen-0.8.0.crate",
         "sha256": "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815",
-        "dest": "cargo/vendor",
-        "dest-filename": "phf_codegen-0.8.0.crate"
+        "dest": "cargo/vendor/phf_codegen-0.8.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815\", \"files\": {}}",
         "dest": "cargo/vendor/phf_codegen-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/phf_generator/phf_generator-0.8.0.crate",
         "sha256": "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526",
-        "dest": "cargo/vendor",
-        "dest-filename": "phf_generator-0.8.0.crate"
+        "dest": "cargo/vendor/phf_generator-0.8.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2217367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526\", \"files\": {}}",
         "dest": "cargo/vendor/phf_generator-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/phf_generator/phf_generator-0.10.0.crate",
         "sha256": "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6",
-        "dest": "cargo/vendor",
-        "dest-filename": "phf_generator-0.10.0.crate"
+        "dest": "cargo/vendor/phf_generator-0.10.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6\", \"files\": {}}",
         "dest": "cargo/vendor/phf_generator-0.10.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/phf_shared/phf_shared-0.8.0.crate",
         "sha256": "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7",
-        "dest": "cargo/vendor",
-        "dest-filename": "phf_shared-0.8.0.crate"
+        "dest": "cargo/vendor/phf_shared-0.8.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7\", \"files\": {}}",
         "dest": "cargo/vendor/phf_shared-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/phf_shared/phf_shared-0.10.0.crate",
         "sha256": "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096",
-        "dest": "cargo/vendor",
-        "dest-filename": "phf_shared-0.10.0.crate"
+        "dest": "cargo/vendor/phf_shared-0.10.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096\", \"files\": {}}",
         "dest": "cargo/vendor/phf_shared-0.10.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pin-project/pin-project-1.0.12.crate",
         "sha256": "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc",
-        "dest": "cargo/vendor",
-        "dest-filename": "pin-project-1.0.12.crate"
+        "dest": "cargo/vendor/pin-project-1.0.12"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc\", \"files\": {}}",
         "dest": "cargo/vendor/pin-project-1.0.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pin-project-internal/pin-project-internal-1.0.12.crate",
         "sha256": "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55",
-        "dest": "cargo/vendor",
-        "dest-filename": "pin-project-internal-1.0.12.crate"
+        "dest": "cargo/vendor/pin-project-internal-1.0.12"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55\", \"files\": {}}",
         "dest": "cargo/vendor/pin-project-internal-1.0.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pin-project-lite/pin-project-lite-0.2.9.crate",
         "sha256": "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116",
-        "dest": "cargo/vendor",
-        "dest-filename": "pin-project-lite-0.2.9.crate"
+        "dest": "cargo/vendor/pin-project-lite-0.2.9"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116\", \"files\": {}}",
         "dest": "cargo/vendor/pin-project-lite-0.2.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pin-utils/pin-utils-0.1.0.crate",
         "sha256": "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184",
-        "dest": "cargo/vendor",
-        "dest-filename": "pin-utils-0.1.0.crate"
+        "dest": "cargo/vendor/pin-utils-0.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184\", \"files\": {}}",
         "dest": "cargo/vendor/pin-utils-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pkg-config/pkg-config-0.3.25.crate",
         "sha256": "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae",
-        "dest": "cargo/vendor",
-        "dest-filename": "pkg-config-0.3.25.crate"
+        "dest": "cargo/vendor/pkg-config-0.3.25"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%221df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae\", \"files\": {}}",
         "dest": "cargo/vendor/pkg-config-0.3.25",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pnet_base/pnet_base-0.30.0.crate",
         "sha256": "2e88341c6c842f89bdc7287f7b1e26b6fa64fa11c7ea3756971e6f18cd2510c4",
-        "dest": "cargo/vendor",
-        "dest-filename": "pnet_base-0.30.0.crate"
+        "dest": "cargo/vendor/pnet_base-0.30.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222e88341c6c842f89bdc7287f7b1e26b6fa64fa11c7ea3756971e6f18cd2510c4%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2e88341c6c842f89bdc7287f7b1e26b6fa64fa11c7ea3756971e6f18cd2510c4\", \"files\": {}}",
         "dest": "cargo/vendor/pnet_base-0.30.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pnet_macros/pnet_macros-0.30.0.crate",
         "sha256": "ebfcdc9c072966723026b3596a1f655fb8bbfe0142f9770f8d481aee4459d6b9",
-        "dest": "cargo/vendor",
-        "dest-filename": "pnet_macros-0.30.0.crate"
+        "dest": "cargo/vendor/pnet_macros-0.30.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ebfcdc9c072966723026b3596a1f655fb8bbfe0142f9770f8d481aee4459d6b9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ebfcdc9c072966723026b3596a1f655fb8bbfe0142f9770f8d481aee4459d6b9\", \"files\": {}}",
         "dest": "cargo/vendor/pnet_macros-0.30.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pnet_macros_support/pnet_macros_support-0.30.0.crate",
         "sha256": "bba532f5a4b320c029d89e612671fb621851b3b07e972c53850d34130033a5cd",
-        "dest": "cargo/vendor",
-        "dest-filename": "pnet_macros_support-0.30.0.crate"
+        "dest": "cargo/vendor/pnet_macros_support-0.30.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22bba532f5a4b320c029d89e612671fb621851b3b07e972c53850d34130033a5cd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"bba532f5a4b320c029d89e612671fb621851b3b07e972c53850d34130033a5cd\", \"files\": {}}",
         "dest": "cargo/vendor/pnet_macros_support-0.30.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pnet_packet/pnet_packet-0.30.0.crate",
         "sha256": "7009716ac86091c1b6e2cdec95a2b028c880f516054c1ec11edd02f9f463cbde",
-        "dest": "cargo/vendor",
-        "dest-filename": "pnet_packet-0.30.0.crate"
+        "dest": "cargo/vendor/pnet_packet-0.30.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227009716ac86091c1b6e2cdec95a2b028c880f516054c1ec11edd02f9f463cbde%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7009716ac86091c1b6e2cdec95a2b028c880f516054c1ec11edd02f9f463cbde\", \"files\": {}}",
         "dest": "cargo/vendor/pnet_packet-0.30.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/png/png-0.16.8.crate",
         "sha256": "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6",
-        "dest": "cargo/vendor",
-        "dest-filename": "png-0.16.8.crate"
+        "dest": "cargo/vendor/png-0.16.8"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6\", \"files\": {}}",
         "dest": "cargo/vendor/png-0.16.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/polyval/polyval-0.5.3.crate",
         "sha256": "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1",
-        "dest": "cargo/vendor",
-        "dest-filename": "polyval-0.5.3.crate"
+        "dest": "cargo/vendor/polyval-0.5.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1\", \"files\": {}}",
         "dest": "cargo/vendor/polyval-0.5.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ppv-lite86/ppv-lite86-0.2.16.crate",
         "sha256": "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872",
-        "dest": "cargo/vendor",
-        "dest-filename": "ppv-lite86-0.2.16.crate"
+        "dest": "cargo/vendor/ppv-lite86-0.2.16"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872\", \"files\": {}}",
         "dest": "cargo/vendor/ppv-lite86-0.2.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/precomputed-hash/precomputed-hash-0.1.1.crate",
         "sha256": "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c",
-        "dest": "cargo/vendor",
-        "dest-filename": "precomputed-hash-0.1.1.crate"
+        "dest": "cargo/vendor/precomputed-hash-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c\", \"files\": {}}",
         "dest": "cargo/vendor/precomputed-hash-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/proc-macro-crate/proc-macro-crate-1.2.1.crate",
         "sha256": "eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9",
-        "dest": "cargo/vendor",
-        "dest-filename": "proc-macro-crate-1.2.1.crate"
+        "dest": "cargo/vendor/proc-macro-crate-1.2.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"eda0fc3b0fb7c975631757e14d9049da17374063edb6ebbcbc54d880d4fe94e9\", \"files\": {}}",
         "dest": "cargo/vendor/proc-macro-crate-1.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/proc-macro-error/proc-macro-error-1.0.4.crate",
         "sha256": "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c",
-        "dest": "cargo/vendor",
-        "dest-filename": "proc-macro-error-1.0.4.crate"
+        "dest": "cargo/vendor/proc-macro-error-1.0.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c\", \"files\": {}}",
         "dest": "cargo/vendor/proc-macro-error-1.0.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/proc-macro-error-attr/proc-macro-error-attr-1.0.4.crate",
         "sha256": "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869",
-        "dest": "cargo/vendor",
-        "dest-filename": "proc-macro-error-attr-1.0.4.crate"
+        "dest": "cargo/vendor/proc-macro-error-attr-1.0.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869\", \"files\": {}}",
         "dest": "cargo/vendor/proc-macro-error-attr-1.0.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/proc-macro2/proc-macro2-1.0.43.crate",
         "sha256": "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab",
-        "dest": "cargo/vendor",
-        "dest-filename": "proc-macro2-1.0.43.crate"
+        "dest": "cargo/vendor/proc-macro2-1.0.43"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab\", \"files\": {}}",
         "dest": "cargo/vendor/proc-macro2-1.0.43",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/proc-macro2-diagnostics/proc-macro2-diagnostics-0.9.1.crate",
         "sha256": "4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada",
-        "dest": "cargo/vendor",
-        "dest-filename": "proc-macro2-diagnostics-0.9.1.crate"
+        "dest": "cargo/vendor/proc-macro2-diagnostics-0.9.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4bf29726d67464d49fa6224a1d07936a8c08bb3fba727c7493f6cf1616fdaada\", \"files\": {}}",
         "dest": "cargo/vendor/proc-macro2-diagnostics-0.9.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/profiling/profiling-1.0.6.crate",
         "sha256": "2f61dcf0b917cd75d4521d7343d1ffff3d1583054133c9b5cbea3375c703c40d",
-        "dest": "cargo/vendor",
-        "dest-filename": "profiling-1.0.6.crate"
+        "dest": "cargo/vendor/profiling-1.0.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222f61dcf0b917cd75d4521d7343d1ffff3d1583054133c9b5cbea3375c703c40d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2f61dcf0b917cd75d4521d7343d1ffff3d1583054133c9b5cbea3375c703c40d\", \"files\": {}}",
         "dest": "cargo/vendor/profiling-1.0.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/prometheus/prometheus-0.12.0.crate",
         "sha256": "5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c",
-        "dest": "cargo/vendor",
-        "dest-filename": "prometheus-0.12.0.crate"
+        "dest": "cargo/vendor/prometheus-0.12.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5986aa8d62380092d2f50f8b1cdba9cb9b6731ffd4b25b51fd126b6c3e05b99c\", \"files\": {}}",
         "dest": "cargo/vendor/prometheus-0.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/protobuf/protobuf-2.27.1.crate",
         "sha256": "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96",
-        "dest": "cargo/vendor",
-        "dest-filename": "protobuf-2.27.1.crate"
+        "dest": "cargo/vendor/protobuf-2.27.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96\", \"files\": {}}",
         "dest": "cargo/vendor/protobuf-2.27.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pulldown-cmark/pulldown-cmark-0.7.2.crate",
         "sha256": "ca36dea94d187597e104a5c8e4b07576a8a45aa5db48a65e12940d3eb7461f55",
-        "dest": "cargo/vendor",
-        "dest-filename": "pulldown-cmark-0.7.2.crate"
+        "dest": "cargo/vendor/pulldown-cmark-0.7.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ca36dea94d187597e104a5c8e4b07576a8a45aa5db48a65e12940d3eb7461f55%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ca36dea94d187597e104a5c8e4b07576a8a45aa5db48a65e12940d3eb7461f55\", \"files\": {}}",
         "dest": "cargo/vendor/pulldown-cmark-0.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/pulldown-cmark/pulldown-cmark-0.8.0.crate",
         "sha256": "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8",
-        "dest": "cargo/vendor",
-        "dest-filename": "pulldown-cmark-0.8.0.crate"
+        "dest": "cargo/vendor/pulldown-cmark-0.8.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8\", \"files\": {}}",
         "dest": "cargo/vendor/pulldown-cmark-0.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/quick-xml/quick-xml-0.20.0.crate",
         "sha256": "26aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd",
-        "dest": "cargo/vendor",
-        "dest-filename": "quick-xml-0.20.0.crate"
+        "dest": "cargo/vendor/quick-xml-0.20.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2226aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"26aab6b48e2590e4a64d1ed808749ba06257882b461d01ca71baeb747074a6dd\", \"files\": {}}",
         "dest": "cargo/vendor/quick-xml-0.20.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/quote/quote-1.0.21.crate",
         "sha256": "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179",
-        "dest": "cargo/vendor",
-        "dest-filename": "quote-1.0.21.crate"
+        "dest": "cargo/vendor/quote-1.0.21"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179\", \"files\": {}}",
         "dest": "cargo/vendor/quote-1.0.21",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/r2d2/r2d2-0.8.10.crate",
         "sha256": "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93",
-        "dest": "cargo/vendor",
-        "dest-filename": "r2d2-0.8.10.crate"
+        "dest": "cargo/vendor/r2d2-0.8.10"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2251de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93\", \"files\": {}}",
         "dest": "cargo/vendor/r2d2-0.8.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rand/rand-0.7.3.crate",
         "sha256": "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03",
-        "dest": "cargo/vendor",
-        "dest-filename": "rand-0.7.3.crate"
+        "dest": "cargo/vendor/rand-0.7.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03\", \"files\": {}}",
         "dest": "cargo/vendor/rand-0.7.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rand/rand-0.8.5.crate",
         "sha256": "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404",
-        "dest": "cargo/vendor",
-        "dest-filename": "rand-0.8.5.crate"
+        "dest": "cargo/vendor/rand-0.8.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2234af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404\", \"files\": {}}",
         "dest": "cargo/vendor/rand-0.8.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.2.2.crate",
         "sha256": "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402",
-        "dest": "cargo/vendor",
-        "dest-filename": "rand_chacha-0.2.2.crate"
+        "dest": "cargo/vendor/rand_chacha-0.2.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402\", \"files\": {}}",
         "dest": "cargo/vendor/rand_chacha-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rand_chacha/rand_chacha-0.3.1.crate",
         "sha256": "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88",
-        "dest": "cargo/vendor",
-        "dest-filename": "rand_chacha-0.3.1.crate"
+        "dest": "cargo/vendor/rand_chacha-0.3.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88\", \"files\": {}}",
         "dest": "cargo/vendor/rand_chacha-0.3.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rand_core/rand_core-0.5.1.crate",
         "sha256": "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19",
-        "dest": "cargo/vendor",
-        "dest-filename": "rand_core-0.5.1.crate"
+        "dest": "cargo/vendor/rand_core-0.5.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2290bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19\", \"files\": {}}",
         "dest": "cargo/vendor/rand_core-0.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rand_core/rand_core-0.6.3.crate",
         "sha256": "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7",
-        "dest": "cargo/vendor",
-        "dest-filename": "rand_core-0.6.3.crate"
+        "dest": "cargo/vendor/rand_core-0.6.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7\", \"files\": {}}",
         "dest": "cargo/vendor/rand_core-0.6.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rand_hc/rand_hc-0.2.0.crate",
         "sha256": "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c",
-        "dest": "cargo/vendor",
-        "dest-filename": "rand_hc-0.2.0.crate"
+        "dest": "cargo/vendor/rand_hc-0.2.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c\", \"files\": {}}",
         "dest": "cargo/vendor/rand_hc-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rand_pcg/rand_pcg-0.2.1.crate",
         "sha256": "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429",
-        "dest": "cargo/vendor",
-        "dest-filename": "rand_pcg-0.2.1.crate"
+        "dest": "cargo/vendor/rand_pcg-0.2.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2216abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429\", \"files\": {}}",
         "dest": "cargo/vendor/rand_pcg-0.2.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/range-alloc/range-alloc-0.1.2.crate",
         "sha256": "63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6",
-        "dest": "cargo/vendor",
-        "dest-filename": "range-alloc-0.1.2.crate"
+        "dest": "cargo/vendor/range-alloc-0.1.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2263e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"63e935c45e09cc6dcf00d2f0b2d630a58f4095320223d47fc68918722f0538b6\", \"files\": {}}",
         "dest": "cargo/vendor/range-alloc-0.1.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/raw-window-handle/raw-window-handle-0.3.4.crate",
         "sha256": "e28f55143d0548dad60bb4fbdc835a3d7ac6acc3324506450c5fdd6e42903a76",
-        "dest": "cargo/vendor",
-        "dest-filename": "raw-window-handle-0.3.4.crate"
+        "dest": "cargo/vendor/raw-window-handle-0.3.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e28f55143d0548dad60bb4fbdc835a3d7ac6acc3324506450c5fdd6e42903a76%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e28f55143d0548dad60bb4fbdc835a3d7ac6acc3324506450c5fdd6e42903a76\", \"files\": {}}",
         "dest": "cargo/vendor/raw-window-handle-0.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/raw-window-handle/raw-window-handle-0.4.3.crate",
         "sha256": "b800beb9b6e7d2df1fe337c9e3d04e3af22a124460fb4c30fcc22c9117cefb41",
-        "dest": "cargo/vendor",
-        "dest-filename": "raw-window-handle-0.4.3.crate"
+        "dest": "cargo/vendor/raw-window-handle-0.4.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b800beb9b6e7d2df1fe337c9e3d04e3af22a124460fb4c30fcc22c9117cefb41%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b800beb9b6e7d2df1fe337c9e3d04e3af22a124460fb4c30fcc22c9117cefb41\", \"files\": {}}",
         "dest": "cargo/vendor/raw-window-handle-0.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rayon/rayon-1.5.3.crate",
         "sha256": "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d",
-        "dest": "cargo/vendor",
-        "dest-filename": "rayon-1.5.3.crate"
+        "dest": "cargo/vendor/rayon-1.5.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d\", \"files\": {}}",
         "dest": "cargo/vendor/rayon-1.5.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rayon-core/rayon-core-1.9.3.crate",
         "sha256": "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f",
-        "dest": "cargo/vendor",
-        "dest-filename": "rayon-core-1.9.3.crate"
+        "dest": "cargo/vendor/rayon-core-1.9.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f\", \"files\": {}}",
         "dest": "cargo/vendor/rayon-core-1.9.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/redox_syscall/redox_syscall-0.2.16.crate",
         "sha256": "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a",
-        "dest": "cargo/vendor",
-        "dest-filename": "redox_syscall-0.2.16.crate"
+        "dest": "cargo/vendor/redox_syscall-0.2.16"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a\", \"files\": {}}",
         "dest": "cargo/vendor/redox_syscall-0.2.16",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/redox_users/redox_users-0.4.3.crate",
         "sha256": "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b",
-        "dest": "cargo/vendor",
-        "dest-filename": "redox_users-0.4.3.crate"
+        "dest": "cargo/vendor/redox_users-0.4.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b\", \"files\": {}}",
         "dest": "cargo/vendor/redox_users-0.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ref-cast/ref-cast-1.0.9.crate",
         "sha256": "ed13bcd201494ab44900a96490291651d200730904221832b9547d24a87d332b",
-        "dest": "cargo/vendor",
-        "dest-filename": "ref-cast-1.0.9.crate"
+        "dest": "cargo/vendor/ref-cast-1.0.9"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ed13bcd201494ab44900a96490291651d200730904221832b9547d24a87d332b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ed13bcd201494ab44900a96490291651d200730904221832b9547d24a87d332b\", \"files\": {}}",
         "dest": "cargo/vendor/ref-cast-1.0.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ref-cast-impl/ref-cast-impl-1.0.9.crate",
         "sha256": "5234cd6063258a5e32903b53b1b6ac043a0541c8adc1f610f67b0326c7a578fa",
-        "dest": "cargo/vendor",
-        "dest-filename": "ref-cast-impl-1.0.9.crate"
+        "dest": "cargo/vendor/ref-cast-impl-1.0.9"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225234cd6063258a5e32903b53b1b6ac043a0541c8adc1f610f67b0326c7a578fa%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5234cd6063258a5e32903b53b1b6ac043a0541c8adc1f610f67b0326c7a578fa\", \"files\": {}}",
         "dest": "cargo/vendor/ref-cast-impl-1.0.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/regex/regex-1.6.0.crate",
         "sha256": "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b",
-        "dest": "cargo/vendor",
-        "dest-filename": "regex-1.6.0.crate"
+        "dest": "cargo/vendor/regex-1.6.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b\", \"files\": {}}",
         "dest": "cargo/vendor/regex-1.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/regex-automata/regex-automata-0.1.10.crate",
         "sha256": "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132",
-        "dest": "cargo/vendor",
-        "dest-filename": "regex-automata-0.1.10.crate"
+        "dest": "cargo/vendor/regex-automata-0.1.10"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132\", \"files\": {}}",
         "dest": "cargo/vendor/regex-automata-0.1.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/regex-syntax/regex-syntax-0.6.27.crate",
         "sha256": "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244",
-        "dest": "cargo/vendor",
-        "dest-filename": "regex-syntax-0.6.27.crate"
+        "dest": "cargo/vendor/regex-syntax-0.6.27"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244\", \"files\": {}}",
         "dest": "cargo/vendor/regex-syntax-0.6.27",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/remove_dir_all/remove_dir_all-0.5.3.crate",
         "sha256": "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7",
-        "dest": "cargo/vendor",
-        "dest-filename": "remove_dir_all-0.5.3.crate"
+        "dest": "cargo/vendor/remove_dir_all-0.5.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7\", \"files\": {}}",
         "dest": "cargo/vendor/remove_dir_all-0.5.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/renderdoc-sys/renderdoc-sys-0.7.1.crate",
         "sha256": "f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157",
-        "dest": "cargo/vendor",
-        "dest-filename": "renderdoc-sys-0.7.1.crate"
+        "dest": "cargo/vendor/renderdoc-sys-0.7.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f1382d1f0a252c4bf97dc20d979a2fdd05b024acd7c2ed0f7595d7817666a157\", \"files\": {}}",
         "dest": "cargo/vendor/renderdoc-sys-0.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/reqwest/reqwest-0.11.11.crate",
         "sha256": "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92",
-        "dest": "cargo/vendor",
-        "dest-filename": "reqwest-0.11.11.crate"
+        "dest": "cargo/vendor/reqwest-0.11.11"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92\", \"files\": {}}",
         "dest": "cargo/vendor/reqwest-0.11.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ring/ring-0.16.20.crate",
         "sha256": "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc",
-        "dest": "cargo/vendor",
-        "dest-filename": "ring-0.16.20.crate"
+        "dest": "cargo/vendor/ring-0.16.20"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc\", \"files\": {}}",
         "dest": "cargo/vendor/ring-0.16.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rocket/rocket-0.5.0-rc.2.crate",
         "sha256": "98ead083fce4a405feb349cf09abdf64471c6077f14e0ce59364aa90d4b99317",
-        "dest": "cargo/vendor",
-        "dest-filename": "rocket-0.5.0-rc.2.crate"
+        "dest": "cargo/vendor/rocket-0.5.0-rc.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2298ead083fce4a405feb349cf09abdf64471c6077f14e0ce59364aa90d4b99317%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"98ead083fce4a405feb349cf09abdf64471c6077f14e0ce59364aa90d4b99317\", \"files\": {}}",
         "dest": "cargo/vendor/rocket-0.5.0-rc.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rocket_codegen/rocket_codegen-0.5.0-rc.2.crate",
         "sha256": "d6aeb6bb9c61e9cd2c00d70ea267bf36f76a4cc615e5908b349c2f9d93999b47",
-        "dest": "cargo/vendor",
-        "dest-filename": "rocket_codegen-0.5.0-rc.2.crate"
+        "dest": "cargo/vendor/rocket_codegen-0.5.0-rc.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d6aeb6bb9c61e9cd2c00d70ea267bf36f76a4cc615e5908b349c2f9d93999b47%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d6aeb6bb9c61e9cd2c00d70ea267bf36f76a4cc615e5908b349c2f9d93999b47\", \"files\": {}}",
         "dest": "cargo/vendor/rocket_codegen-0.5.0-rc.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rocket_http/rocket_http-0.5.0-rc.2.crate",
         "sha256": "2ded65d127954de3c12471630bf4b81a2792f065984461e65b91d0fdaafc17a2",
-        "dest": "cargo/vendor",
-        "dest-filename": "rocket_http-0.5.0-rc.2.crate"
+        "dest": "cargo/vendor/rocket_http-0.5.0-rc.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222ded65d127954de3c12471630bf4b81a2792f065984461e65b91d0fdaafc17a2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2ded65d127954de3c12471630bf4b81a2792f065984461e65b91d0fdaafc17a2\", \"files\": {}}",
         "dest": "cargo/vendor/rocket_http-0.5.0-rc.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rocket_sync_db_pools/rocket_sync_db_pools-0.1.0-rc.2.crate",
         "sha256": "5fa48b6ab25013e9812f1b0c592741900b3a2a83c0936292e0565c0ac842f558",
-        "dest": "cargo/vendor",
-        "dest-filename": "rocket_sync_db_pools-0.1.0-rc.2.crate"
+        "dest": "cargo/vendor/rocket_sync_db_pools-0.1.0-rc.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225fa48b6ab25013e9812f1b0c592741900b3a2a83c0936292e0565c0ac842f558%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5fa48b6ab25013e9812f1b0c592741900b3a2a83c0936292e0565c0ac842f558\", \"files\": {}}",
         "dest": "cargo/vendor/rocket_sync_db_pools-0.1.0-rc.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rocket_sync_db_pools_codegen/rocket_sync_db_pools_codegen-0.1.0-rc.2.crate",
         "sha256": "280ef2d232923e69cb93da156972eb5476a7cce5ba44843f6608f46a4abf7aab",
-        "dest": "cargo/vendor",
-        "dest-filename": "rocket_sync_db_pools_codegen-0.1.0-rc.2.crate"
+        "dest": "cargo/vendor/rocket_sync_db_pools_codegen-0.1.0-rc.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22280ef2d232923e69cb93da156972eb5476a7cce5ba44843f6608f46a4abf7aab%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"280ef2d232923e69cb93da156972eb5476a7cce5ba44843f6608f46a4abf7aab\", \"files\": {}}",
         "dest": "cargo/vendor/rocket_sync_db_pools_codegen-0.1.0-rc.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ron/ron-0.6.6.crate",
         "sha256": "86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4",
-        "dest": "cargo/vendor",
-        "dest-filename": "ron-0.6.6.crate"
+        "dest": "cargo/vendor/ron-0.6.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2286018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"86018df177b1beef6c7c8ef949969c4f7cb9a9344181b92486b23c79995bdaa4\", \"files\": {}}",
         "dest": "cargo/vendor/ron-0.6.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ron/ron-0.7.1.crate",
         "sha256": "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a",
-        "dest": "cargo/vendor",
-        "dest-filename": "ron-0.7.1.crate"
+        "dest": "cargo/vendor/ron-0.7.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2288073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a\", \"files\": {}}",
         "dest": "cargo/vendor/ron-0.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rss/rss-1.10.0.crate",
         "sha256": "02e70d6ae72f8a4333af8ce9dce58942020528430eb0d46ee2fcb5e8d4d16377",
-        "dest": "cargo/vendor",
-        "dest-filename": "rss-1.10.0.crate"
+        "dest": "cargo/vendor/rss-1.10.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2202e70d6ae72f8a4333af8ce9dce58942020528430eb0d46ee2fcb5e8d4d16377%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"02e70d6ae72f8a4333af8ce9dce58942020528430eb0d46ee2fcb5e8d4d16377\", \"files\": {}}",
         "dest": "cargo/vendor/rss-1.10.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rustc-demangle/rustc-demangle-0.1.21.crate",
         "sha256": "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342",
-        "dest": "cargo/vendor",
-        "dest-filename": "rustc-demangle-0.1.21.crate"
+        "dest": "cargo/vendor/rustc-demangle-0.1.21"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342\", \"files\": {}}",
         "dest": "cargo/vendor/rustc-demangle-0.1.21",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rustc-hash/rustc-hash-1.1.0.crate",
         "sha256": "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2",
-        "dest": "cargo/vendor",
-        "dest-filename": "rustc-hash-1.1.0.crate"
+        "dest": "cargo/vendor/rustc-hash-1.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2208d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2\", \"files\": {}}",
         "dest": "cargo/vendor/rustc-hash-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rustc_version/rustc_version-0.4.0.crate",
         "sha256": "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366",
-        "dest": "cargo/vendor",
-        "dest-filename": "rustc_version-0.4.0.crate"
+        "dest": "cargo/vendor/rustc_version-0.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366\", \"files\": {}}",
         "dest": "cargo/vendor/rustc_version-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rustls/rustls-0.20.6.crate",
         "sha256": "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033",
-        "dest": "cargo/vendor",
-        "dest-filename": "rustls-0.20.6.crate"
+        "dest": "cargo/vendor/rustls-0.20.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033\", \"files\": {}}",
         "dest": "cargo/vendor/rustls-0.20.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rustls-pemfile/rustls-pemfile-1.0.1.crate",
         "sha256": "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55",
-        "dest": "cargo/vendor",
-        "dest-filename": "rustls-pemfile-1.0.1.crate"
+        "dest": "cargo/vendor/rustls-pemfile-1.0.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55\", \"files\": {}}",
         "dest": "cargo/vendor/rustls-pemfile-1.0.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/rustversion/rustversion-1.0.9.crate",
         "sha256": "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8",
-        "dest": "cargo/vendor",
-        "dest-filename": "rustversion-1.0.9.crate"
+        "dest": "cargo/vendor/rustversion-1.0.9"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2297477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8\", \"files\": {}}",
         "dest": "cargo/vendor/rustversion-1.0.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ryu/ryu-1.0.11.crate",
         "sha256": "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09",
-        "dest": "cargo/vendor",
-        "dest-filename": "ryu-1.0.11.crate"
+        "dest": "cargo/vendor/ryu-1.0.11"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09\", \"files\": {}}",
         "dest": "cargo/vendor/ryu-1.0.11",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/schannel/schannel-0.1.20.crate",
         "sha256": "88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2",
-        "dest": "cargo/vendor",
-        "dest-filename": "schannel-0.1.20.crate"
+        "dest": "cargo/vendor/schannel-0.1.20"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2288d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"88d6731146462ea25d9244b2ed5fd1d716d25c52e4d54aa4fb0f3c4e9854dbe2\", \"files\": {}}",
         "dest": "cargo/vendor/schannel-0.1.20",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/scheduled-thread-pool/scheduled-thread-pool-0.2.6.crate",
         "sha256": "977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf",
-        "dest": "cargo/vendor",
-        "dest-filename": "scheduled-thread-pool-0.2.6.crate"
+        "dest": "cargo/vendor/scheduled-thread-pool-0.2.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"977a7519bff143a44f842fd07e80ad1329295bd71686457f18e496736f4bf9bf\", \"files\": {}}",
         "dest": "cargo/vendor/scheduled-thread-pool-0.2.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/scoped-tls/scoped-tls-1.0.0.crate",
         "sha256": "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2",
-        "dest": "cargo/vendor",
-        "dest-filename": "scoped-tls-1.0.0.crate"
+        "dest": "cargo/vendor/scoped-tls-1.0.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2\", \"files\": {}}",
         "dest": "cargo/vendor/scoped-tls-1.0.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/scopeguard/scopeguard-1.1.0.crate",
         "sha256": "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd",
-        "dest": "cargo/vendor",
-        "dest-filename": "scopeguard-1.1.0.crate"
+        "dest": "cargo/vendor/scopeguard-1.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd\", \"files\": {}}",
         "dest": "cargo/vendor/scopeguard-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/sct/sct-0.7.0.crate",
         "sha256": "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4",
-        "dest": "cargo/vendor",
-        "dest-filename": "sct-0.7.0.crate"
+        "dest": "cargo/vendor/sct-0.7.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4\", \"files\": {}}",
         "dest": "cargo/vendor/sct-0.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/security-framework/security-framework-2.7.0.crate",
         "sha256": "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c",
-        "dest": "cargo/vendor",
-        "dest-filename": "security-framework-2.7.0.crate"
+        "dest": "cargo/vendor/security-framework-2.7.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c\", \"files\": {}}",
         "dest": "cargo/vendor/security-framework-2.7.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/security-framework-sys/security-framework-sys-2.6.1.crate",
         "sha256": "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556",
-        "dest": "cargo/vendor",
-        "dest-filename": "security-framework-sys-2.6.1.crate"
+        "dest": "cargo/vendor/security-framework-sys-2.6.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556\", \"files\": {}}",
         "dest": "cargo/vendor/security-framework-sys-2.6.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/self_update/self_update-0.27.0.crate",
         "sha256": "6fb85f1802f7b987237b8525c0fde86ea86f31c957c1875467c727d5b921179c",
-        "dest": "cargo/vendor",
-        "dest-filename": "self_update-0.27.0.crate"
+        "dest": "cargo/vendor/self_update-0.27.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226fb85f1802f7b987237b8525c0fde86ea86f31c957c1875467c727d5b921179c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6fb85f1802f7b987237b8525c0fde86ea86f31c957c1875467c727d5b921179c\", \"files\": {}}",
         "dest": "cargo/vendor/self_update-0.27.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/semver/semver-0.11.0.crate",
         "sha256": "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6",
-        "dest": "cargo/vendor",
-        "dest-filename": "semver-0.11.0.crate"
+        "dest": "cargo/vendor/semver-0.11.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6\", \"files\": {}}",
         "dest": "cargo/vendor/semver-0.11.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/semver/semver-1.0.13.crate",
         "sha256": "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711",
-        "dest": "cargo/vendor",
-        "dest-filename": "semver-1.0.13.crate"
+        "dest": "cargo/vendor/semver-1.0.13"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2293f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711\", \"files\": {}}",
         "dest": "cargo/vendor/semver-1.0.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/semver-parser/semver-parser-0.10.2.crate",
         "sha256": "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7",
-        "dest": "cargo/vendor",
-        "dest-filename": "semver-parser-0.10.2.crate"
+        "dest": "cargo/vendor/semver-parser-0.10.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2200b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7\", \"files\": {}}",
         "dest": "cargo/vendor/semver-parser-0.10.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/serde/serde-1.0.144.crate",
         "sha256": "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860",
-        "dest": "cargo/vendor",
-        "dest-filename": "serde-1.0.144.crate"
+        "dest": "cargo/vendor/serde-1.0.144"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860\", \"files\": {}}",
         "dest": "cargo/vendor/serde-1.0.144",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/serde_derive/serde_derive-1.0.144.crate",
         "sha256": "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00",
-        "dest": "cargo/vendor",
-        "dest-filename": "serde_derive-1.0.144.crate"
+        "dest": "cargo/vendor/serde_derive-1.0.144"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2294ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00\", \"files\": {}}",
         "dest": "cargo/vendor/serde_derive-1.0.144",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/serde_json/serde_json-1.0.85.crate",
         "sha256": "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44",
-        "dest": "cargo/vendor",
-        "dest-filename": "serde_json-1.0.85.crate"
+        "dest": "cargo/vendor/serde_json-1.0.85"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44\", \"files\": {}}",
         "dest": "cargo/vendor/serde_json-1.0.85",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/serde_path_to_error/serde_path_to_error-0.1.8.crate",
         "sha256": "184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d",
-        "dest": "cargo/vendor",
-        "dest-filename": "serde_path_to_error-0.1.8.crate"
+        "dest": "cargo/vendor/serde_path_to_error-0.1.8"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"184c643044780f7ceb59104cef98a5a6f12cb2288a7bc701ab93a362b49fd47d\", \"files\": {}}",
         "dest": "cargo/vendor/serde_path_to_error-0.1.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/serde_urlencoded/serde_urlencoded-0.7.1.crate",
         "sha256": "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd",
-        "dest": "cargo/vendor",
-        "dest-filename": "serde_urlencoded-0.7.1.crate"
+        "dest": "cargo/vendor/serde_urlencoded-0.7.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd\", \"files\": {}}",
         "dest": "cargo/vendor/serde_urlencoded-0.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/sha2/sha2-0.10.5.crate",
         "sha256": "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5",
-        "dest": "cargo/vendor",
-        "dest-filename": "sha2-0.10.5.crate"
+        "dest": "cargo/vendor/sha2-0.10.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5\", \"files\": {}}",
         "dest": "cargo/vendor/sha2-0.10.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/sharded-slab/sharded-slab-0.1.4.crate",
         "sha256": "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31",
-        "dest": "cargo/vendor",
-        "dest-filename": "sharded-slab-0.1.4.crate"
+        "dest": "cargo/vendor/sharded-slab-0.1.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31\", \"files\": {}}",
         "dest": "cargo/vendor/sharded-slab-0.1.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/signal-hook-registry/signal-hook-registry-1.4.0.crate",
         "sha256": "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0",
-        "dest": "cargo/vendor",
-        "dest-filename": "signal-hook-registry-1.4.0.crate"
+        "dest": "cargo/vendor/signal-hook-registry-1.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0\", \"files\": {}}",
         "dest": "cargo/vendor/signal-hook-registry-1.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/simple_asn1/simple_asn1-0.4.1.crate",
         "sha256": "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b",
-        "dest": "cargo/vendor",
-        "dest-filename": "simple_asn1-0.4.1.crate"
+        "dest": "cargo/vendor/simple_asn1-0.4.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b\", \"files\": {}}",
         "dest": "cargo/vendor/simple_asn1-0.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/siphasher/siphasher-0.3.10.crate",
         "sha256": "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de",
-        "dest": "cargo/vendor",
-        "dest-filename": "siphasher-0.3.10.crate"
+        "dest": "cargo/vendor/siphasher-0.3.10"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de\", \"files\": {}}",
         "dest": "cargo/vendor/siphasher-0.3.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/slab/slab-0.4.7.crate",
         "sha256": "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef",
-        "dest": "cargo/vendor",
-        "dest-filename": "slab-0.4.7.crate"
+        "dest": "cargo/vendor/slab-0.4.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef\", \"files\": {}}",
         "dest": "cargo/vendor/slab-0.4.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/slotmap/slotmap-1.0.6.crate",
         "sha256": "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342",
-        "dest": "cargo/vendor",
-        "dest-filename": "slotmap-1.0.6.crate"
+        "dest": "cargo/vendor/slotmap-1.0.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342\", \"files\": {}}",
         "dest": "cargo/vendor/slotmap-1.0.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/smallvec/smallvec-1.9.0.crate",
         "sha256": "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1",
-        "dest": "cargo/vendor",
-        "dest-filename": "smallvec-1.9.0.crate"
+        "dest": "cargo/vendor/smallvec-1.9.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1\", \"files\": {}}",
         "dest": "cargo/vendor/smallvec-1.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/smithay-client-toolkit/smithay-client-toolkit-0.15.4.crate",
         "sha256": "8a28f16a97fa0e8ce563b2774d1e732dd5d4025d2772c5dba0a41a0f90a29da3",
-        "dest": "cargo/vendor",
-        "dest-filename": "smithay-client-toolkit-0.15.4.crate"
+        "dest": "cargo/vendor/smithay-client-toolkit-0.15.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228a28f16a97fa0e8ce563b2774d1e732dd5d4025d2772c5dba0a41a0f90a29da3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8a28f16a97fa0e8ce563b2774d1e732dd5d4025d2772c5dba0a41a0f90a29da3\", \"files\": {}}",
         "dest": "cargo/vendor/smithay-client-toolkit-0.15.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/smithay-client-toolkit/smithay-client-toolkit-0.16.0.crate",
         "sha256": "f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454",
-        "dest": "cargo/vendor",
-        "dest-filename": "smithay-client-toolkit-0.16.0.crate"
+        "dest": "cargo/vendor/smithay-client-toolkit-0.16.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f307c47d32d2715eb2e0ece5589057820e0e5e70d07c247d1063e844e107f454\", \"files\": {}}",
         "dest": "cargo/vendor/smithay-client-toolkit-0.16.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/smithay-clipboard/smithay-clipboard-0.6.6.crate",
         "sha256": "0a345c870a1fae0b1b779085e81b51e614767c239e93503588e54c5b17f4b0e8",
-        "dest": "cargo/vendor",
-        "dest-filename": "smithay-clipboard-0.6.6.crate"
+        "dest": "cargo/vendor/smithay-clipboard-0.6.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220a345c870a1fae0b1b779085e81b51e614767c239e93503588e54c5b17f4b0e8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0a345c870a1fae0b1b779085e81b51e614767c239e93503588e54c5b17f4b0e8\", \"files\": {}}",
         "dest": "cargo/vendor/smithay-clipboard-0.6.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/snafu/snafu-0.7.1.crate",
         "sha256": "5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2",
-        "dest": "cargo/vendor",
-        "dest-filename": "snafu-0.7.1.crate"
+        "dest": "cargo/vendor/snafu-0.7.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5177903bf45656592d9eb5c0e22f408fc023aae51dbe2088889b71633ba451f2\", \"files\": {}}",
         "dest": "cargo/vendor/snafu-0.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/snafu-derive/snafu-derive-0.7.1.crate",
         "sha256": "410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5",
-        "dest": "cargo/vendor",
-        "dest-filename": "snafu-derive-0.7.1.crate"
+        "dest": "cargo/vendor/snafu-derive-0.7.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"410b26ed97440d90ced3e2488c868d56a86e2064f5d7d6f417909b286afe25e5\", \"files\": {}}",
         "dest": "cargo/vendor/snafu-derive-0.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/socket2/socket2-0.4.7.crate",
         "sha256": "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd",
-        "dest": "cargo/vendor",
-        "dest-filename": "socket2-0.4.7.crate"
+        "dest": "cargo/vendor/socket2-0.4.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2202e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd\", \"files\": {}}",
         "dest": "cargo/vendor/socket2-0.4.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/spin/spin-0.5.2.crate",
         "sha256": "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d",
-        "dest": "cargo/vendor",
-        "dest-filename": "spin-0.5.2.crate"
+        "dest": "cargo/vendor/spin-0.5.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d\", \"files\": {}}",
         "dest": "cargo/vendor/spin-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/spin/spin-0.9.4.crate",
         "sha256": "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09",
-        "dest": "cargo/vendor",
-        "dest-filename": "spin-0.9.4.crate"
+        "dest": "cargo/vendor/spin-0.9.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09\", \"files\": {}}",
         "dest": "cargo/vendor/spin-0.9.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/spirv/spirv-0.2.0+1.5.4.crate",
         "sha256": "246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830",
-        "dest": "cargo/vendor",
-        "dest-filename": "spirv-0.2.0+1.5.4.crate"
+        "dest": "cargo/vendor/spirv-0.2.0+1.5.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"246bfa38fe3db3f1dfc8ca5a2cdeb7348c78be2112740cc0ec8ef18b6d94f830\", \"files\": {}}",
         "dest": "cargo/vendor/spirv-0.2.0+1.5.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/stable-pattern/stable-pattern-0.1.0.crate",
         "sha256": "4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045",
-        "dest": "cargo/vendor",
-        "dest-filename": "stable-pattern-0.1.0.crate"
+        "dest": "cargo/vendor/stable-pattern-0.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4564168c00635f88eaed410d5efa8131afa8d8699a612c80c455a0ba05c21045\", \"files\": {}}",
         "dest": "cargo/vendor/stable-pattern-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/stable_deref_trait/stable_deref_trait-1.2.0.crate",
         "sha256": "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3",
-        "dest": "cargo/vendor",
-        "dest-filename": "stable_deref_trait-1.2.0.crate"
+        "dest": "cargo/vendor/stable_deref_trait-1.2.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3\", \"files\": {}}",
         "dest": "cargo/vendor/stable_deref_trait-1.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/state/state-0.5.3.crate",
         "sha256": "dbe866e1e51e8260c9eed836a042a5e7f6726bb2b411dffeaa712e19c388f23b",
-        "dest": "cargo/vendor",
-        "dest-filename": "state-0.5.3.crate"
+        "dest": "cargo/vendor/state-0.5.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22dbe866e1e51e8260c9eed836a042a5e7f6726bb2b411dffeaa712e19c388f23b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"dbe866e1e51e8260c9eed836a042a5e7f6726bb2b411dffeaa712e19c388f23b\", \"files\": {}}",
         "dest": "cargo/vendor/state-0.5.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/static_assertions/static_assertions-1.1.0.crate",
         "sha256": "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f",
-        "dest": "cargo/vendor",
-        "dest-filename": "static_assertions-1.1.0.crate"
+        "dest": "cargo/vendor/static_assertions-1.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f\", \"files\": {}}",
         "dest": "cargo/vendor/static_assertions-1.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/str-buf/str-buf-1.0.6.crate",
         "sha256": "9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0",
-        "dest": "cargo/vendor",
-        "dest-filename": "str-buf-1.0.6.crate"
+        "dest": "cargo/vendor/str-buf-1.0.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9e08d8363704e6c71fc928674353e6b7c23dcea9d82d7012c8faf2a3a025f8d0\", \"files\": {}}",
         "dest": "cargo/vendor/str-buf-1.0.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/string_cache/string_cache-0.8.4.crate",
         "sha256": "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08",
-        "dest": "cargo/vendor",
-        "dest-filename": "string_cache-0.8.4.crate"
+        "dest": "cargo/vendor/string_cache-0.8.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08\", \"files\": {}}",
         "dest": "cargo/vendor/string_cache-0.8.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/string_cache_codegen/string_cache_codegen-0.5.2.crate",
         "sha256": "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988",
-        "dest": "cargo/vendor",
-        "dest-filename": "string_cache_codegen-0.5.2.crate"
+        "dest": "cargo/vendor/string_cache_codegen-0.5.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988\", \"files\": {}}",
         "dest": "cargo/vendor/string_cache_codegen-0.5.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/strip_markdown/strip_markdown-0.2.0.crate",
         "sha256": "32c754386109f9adc8ca62513c51cf81cc2d8502588064103aa8e9f69b4276da",
-        "dest": "cargo/vendor",
-        "dest-filename": "strip_markdown-0.2.0.crate"
+        "dest": "cargo/vendor/strip_markdown-0.2.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2232c754386109f9adc8ca62513c51cf81cc2d8502588064103aa8e9f69b4276da%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"32c754386109f9adc8ca62513c51cf81cc2d8502588064103aa8e9f69b4276da\", \"files\": {}}",
         "dest": "cargo/vendor/strip_markdown-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/strsim/strsim-0.9.3.crate",
         "sha256": "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c",
-        "dest": "cargo/vendor",
-        "dest-filename": "strsim-0.9.3.crate"
+        "dest": "cargo/vendor/strsim-0.9.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c\", \"files\": {}}",
         "dest": "cargo/vendor/strsim-0.9.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/strsim/strsim-0.10.0.crate",
         "sha256": "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623",
-        "dest": "cargo/vendor",
-        "dest-filename": "strsim-0.10.0.crate"
+        "dest": "cargo/vendor/strsim-0.10.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2273473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623\", \"files\": {}}",
         "dest": "cargo/vendor/strsim-0.10.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/subtle/subtle-2.4.1.crate",
         "sha256": "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601",
-        "dest": "cargo/vendor",
-        "dest-filename": "subtle-2.4.1.crate"
+        "dest": "cargo/vendor/subtle-2.4.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601\", \"files\": {}}",
         "dest": "cargo/vendor/subtle-2.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/surge-ping/surge-ping-0.7.2.crate",
         "sha256": "4d33636a95261e9f939742d4712b20f8813a9b3cfaf1510b751096329cd3902b",
-        "dest": "cargo/vendor",
-        "dest-filename": "surge-ping-0.7.2.crate"
+        "dest": "cargo/vendor/surge-ping-0.7.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224d33636a95261e9f939742d4712b20f8813a9b3cfaf1510b751096329cd3902b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4d33636a95261e9f939742d4712b20f8813a9b3cfaf1510b751096329cd3902b\", \"files\": {}}",
         "dest": "cargo/vendor/surge-ping-0.7.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/svg_fmt/svg_fmt-0.4.1.crate",
         "sha256": "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2",
-        "dest": "cargo/vendor",
-        "dest-filename": "svg_fmt-0.4.1.crate"
+        "dest": "cargo/vendor/svg_fmt-0.4.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2\", \"files\": {}}",
         "dest": "cargo/vendor/svg_fmt-0.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/syn/syn-1.0.99.crate",
         "sha256": "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13",
-        "dest": "cargo/vendor",
-        "dest-filename": "syn-1.0.99.crate"
+        "dest": "cargo/vendor/syn-1.0.99"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2258dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13\", \"files\": {}}",
         "dest": "cargo/vendor/syn-1.0.99",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tempfile/tempfile-3.3.0.crate",
         "sha256": "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4",
-        "dest": "cargo/vendor",
-        "dest-filename": "tempfile-3.3.0.crate"
+        "dest": "cargo/vendor/tempfile-3.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4\", \"files\": {}}",
         "dest": "cargo/vendor/tempfile-3.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tendril/tendril-0.4.3.crate",
         "sha256": "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0",
-        "dest": "cargo/vendor",
-        "dest-filename": "tendril-0.4.3.crate"
+        "dest": "cargo/vendor/tendril-0.4.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0\", \"files\": {}}",
         "dest": "cargo/vendor/tendril-0.4.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/termcolor/termcolor-1.1.3.crate",
         "sha256": "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755",
-        "dest": "cargo/vendor",
-        "dest-filename": "termcolor-1.1.3.crate"
+        "dest": "cargo/vendor/termcolor-1.1.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755\", \"files\": {}}",
         "dest": "cargo/vendor/termcolor-1.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/terminal_size/terminal_size-0.1.17.crate",
         "sha256": "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df",
-        "dest": "cargo/vendor",
-        "dest-filename": "terminal_size-0.1.17.crate"
+        "dest": "cargo/vendor/terminal_size-0.1.17"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df\", \"files\": {}}",
         "dest": "cargo/vendor/terminal_size-0.1.17",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/textwrap/textwrap-0.15.0.crate",
         "sha256": "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb",
-        "dest": "cargo/vendor",
-        "dest-filename": "textwrap-0.15.0.crate"
+        "dest": "cargo/vendor/textwrap-0.15.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb\", \"files\": {}}",
         "dest": "cargo/vendor/textwrap-0.15.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/thiserror/thiserror-1.0.34.crate",
         "sha256": "8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252",
-        "dest": "cargo/vendor",
-        "dest-filename": "thiserror-1.0.34.crate"
+        "dest": "cargo/vendor/thiserror-1.0.34"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8c1b05ca9d106ba7d2e31a9dab4a64e7be2cce415321966ea3132c49a656e252\", \"files\": {}}",
         "dest": "cargo/vendor/thiserror-1.0.34",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/thiserror-impl/thiserror-impl-1.0.34.crate",
         "sha256": "e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487",
-        "dest": "cargo/vendor",
-        "dest-filename": "thiserror-impl-1.0.34.crate"
+        "dest": "cargo/vendor/thiserror-impl-1.0.34"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e8f2591983642de85c921015f3f070c665a197ed69e417af436115e3a1407487\", \"files\": {}}",
         "dest": "cargo/vendor/thiserror-impl-1.0.34",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/thread_local/thread_local-1.1.4.crate",
         "sha256": "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180",
-        "dest": "cargo/vendor",
-        "dest-filename": "thread_local-1.1.4.crate"
+        "dest": "cargo/vendor/thread_local-1.1.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180\", \"files\": {}}",
         "dest": "cargo/vendor/thread_local-1.1.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/time/time-0.1.44.crate",
         "sha256": "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255",
-        "dest": "cargo/vendor",
-        "dest-filename": "time-0.1.44.crate"
+        "dest": "cargo/vendor/time-0.1.44"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255\", \"files\": {}}",
         "dest": "cargo/vendor/time-0.1.44",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/time/time-0.3.14.crate",
         "sha256": "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b",
-        "dest": "cargo/vendor",
-        "dest-filename": "time-0.3.14.crate"
+        "dest": "cargo/vendor/time-0.3.14"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b\", \"files\": {}}",
         "dest": "cargo/vendor/time-0.3.14",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/time-macros/time-macros-0.2.4.crate",
         "sha256": "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792",
-        "dest": "cargo/vendor",
-        "dest-filename": "time-macros-0.2.4.crate"
+        "dest": "cargo/vendor/time-macros-0.2.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2242657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792\", \"files\": {}}",
         "dest": "cargo/vendor/time-macros-0.2.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tinyvec/tinyvec-1.6.0.crate",
         "sha256": "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50",
-        "dest": "cargo/vendor",
-        "dest-filename": "tinyvec-1.6.0.crate"
+        "dest": "cargo/vendor/tinyvec-1.6.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2287cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50\", \"files\": {}}",
         "dest": "cargo/vendor/tinyvec-1.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tinyvec_macros/tinyvec_macros-0.1.0.crate",
         "sha256": "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c",
-        "dest": "cargo/vendor",
-        "dest-filename": "tinyvec_macros-0.1.0.crate"
+        "dest": "cargo/vendor/tinyvec_macros-0.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c\", \"files\": {}}",
         "dest": "cargo/vendor/tinyvec_macros-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tokio/tokio-1.21.0.crate",
         "sha256": "89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42",
-        "dest": "cargo/vendor",
-        "dest-filename": "tokio-1.21.0.crate"
+        "dest": "cargo/vendor/tokio-1.21.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2289797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"89797afd69d206ccd11fb0ea560a44bbb87731d020670e79416d442919257d42\", \"files\": {}}",
         "dest": "cargo/vendor/tokio-1.21.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tokio-macros/tokio-macros-1.8.0.crate",
         "sha256": "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484",
-        "dest": "cargo/vendor",
-        "dest-filename": "tokio-macros-1.8.0.crate"
+        "dest": "cargo/vendor/tokio-macros-1.8.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484\", \"files\": {}}",
         "dest": "cargo/vendor/tokio-macros-1.8.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tokio-native-tls/tokio-native-tls-0.3.0.crate",
         "sha256": "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b",
-        "dest": "cargo/vendor",
-        "dest-filename": "tokio-native-tls-0.3.0.crate"
+        "dest": "cargo/vendor/tokio-native-tls-0.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b\", \"files\": {}}",
         "dest": "cargo/vendor/tokio-native-tls-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tokio-rustls/tokio-rustls-0.23.4.crate",
         "sha256": "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59",
-        "dest": "cargo/vendor",
-        "dest-filename": "tokio-rustls-0.23.4.crate"
+        "dest": "cargo/vendor/tokio-rustls-0.23.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59\", \"files\": {}}",
         "dest": "cargo/vendor/tokio-rustls-0.23.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tokio-stream/tokio-stream-0.1.9.crate",
         "sha256": "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9",
-        "dest": "cargo/vendor",
-        "dest-filename": "tokio-stream-0.1.9.crate"
+        "dest": "cargo/vendor/tokio-stream-0.1.9"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9\", \"files\": {}}",
         "dest": "cargo/vendor/tokio-stream-0.1.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tokio-util/tokio-util-0.6.10.crate",
         "sha256": "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507",
-        "dest": "cargo/vendor",
-        "dest-filename": "tokio-util-0.6.10.crate"
+        "dest": "cargo/vendor/tokio-util-0.6.10"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2236943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507\", \"files\": {}}",
         "dest": "cargo/vendor/tokio-util-0.6.10",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tokio-util/tokio-util-0.7.3.crate",
         "sha256": "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45",
-        "dest": "cargo/vendor",
-        "dest-filename": "tokio-util-0.7.3.crate"
+        "dest": "cargo/vendor/tokio-util-0.7.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45\", \"files\": {}}",
         "dest": "cargo/vendor/tokio-util-0.7.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/toml/toml-0.5.9.crate",
         "sha256": "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7",
-        "dest": "cargo/vendor",
-        "dest-filename": "toml-0.5.9.crate"
+        "dest": "cargo/vendor/toml-0.5.9"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7\", \"files\": {}}",
         "dest": "cargo/vendor/toml-0.5.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tower-service/tower-service-0.3.2.crate",
         "sha256": "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52",
-        "dest": "cargo/vendor",
-        "dest-filename": "tower-service-0.3.2.crate"
+        "dest": "cargo/vendor/tower-service-0.3.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52\", \"files\": {}}",
         "dest": "cargo/vendor/tower-service-0.3.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tracing/tracing-0.1.36.crate",
         "sha256": "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307",
-        "dest": "cargo/vendor",
-        "dest-filename": "tracing-0.1.36.crate"
+        "dest": "cargo/vendor/tracing-0.1.36"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%222fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307\", \"files\": {}}",
         "dest": "cargo/vendor/tracing-0.1.36",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tracing-appender/tracing-appender-0.2.2.crate",
         "sha256": "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e",
-        "dest": "cargo/vendor",
-        "dest-filename": "tracing-appender-0.2.2.crate"
+        "dest": "cargo/vendor/tracing-appender-0.2.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2209d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e\", \"files\": {}}",
         "dest": "cargo/vendor/tracing-appender-0.2.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tracing-attributes/tracing-attributes-0.1.22.crate",
         "sha256": "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2",
-        "dest": "cargo/vendor",
-        "dest-filename": "tracing-attributes-0.1.22.crate"
+        "dest": "cargo/vendor/tracing-attributes-0.1.22"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2211c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2\", \"files\": {}}",
         "dest": "cargo/vendor/tracing-attributes-0.1.22",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tracing-core/tracing-core-0.1.29.crate",
         "sha256": "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7",
-        "dest": "cargo/vendor",
-        "dest-filename": "tracing-core-0.1.29.crate"
+        "dest": "cargo/vendor/tracing-core-0.1.29"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7\", \"files\": {}}",
         "dest": "cargo/vendor/tracing-core-0.1.29",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tracing-futures/tracing-futures-0.2.5.crate",
         "sha256": "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2",
-        "dest": "cargo/vendor",
-        "dest-filename": "tracing-futures-0.2.5.crate"
+        "dest": "cargo/vendor/tracing-futures-0.2.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2297d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2\", \"files\": {}}",
         "dest": "cargo/vendor/tracing-futures-0.2.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tracing-log/tracing-log-0.1.3.crate",
         "sha256": "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922",
-        "dest": "cargo/vendor",
-        "dest-filename": "tracing-log-0.1.3.crate"
+        "dest": "cargo/vendor/tracing-log-0.1.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2278ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922\", \"files\": {}}",
         "dest": "cargo/vendor/tracing-log-0.1.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/tracing-subscriber/tracing-subscriber-0.3.15.crate",
         "sha256": "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b",
-        "dest": "cargo/vendor",
-        "dest-filename": "tracing-subscriber-0.3.15.crate"
+        "dest": "cargo/vendor/tracing-subscriber-0.3.15"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2260db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b\", \"files\": {}}",
         "dest": "cargo/vendor/tracing-subscriber-0.3.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/try-lock/try-lock-0.2.3.crate",
         "sha256": "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642",
-        "dest": "cargo/vendor",
-        "dest-filename": "try-lock-0.2.3.crate"
+        "dest": "cargo/vendor/try-lock-0.2.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2259547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642\", \"files\": {}}",
         "dest": "cargo/vendor/try-lock-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ttf-parser/ttf-parser-0.15.2.crate",
         "sha256": "7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd",
-        "dest": "cargo/vendor",
-        "dest-filename": "ttf-parser-0.15.2.crate"
+        "dest": "cargo/vendor/ttf-parser-0.15.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7b3e06c9b9d80ed6b745c7159c40b311ad2916abb34a49e9be2653b90db0d8dd\", \"files\": {}}",
         "dest": "cargo/vendor/ttf-parser-0.15.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/twox-hash/twox-hash-1.6.3.crate",
         "sha256": "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675",
-        "dest": "cargo/vendor",
-        "dest-filename": "twox-hash-1.6.3.crate"
+        "dest": "cargo/vendor/twox-hash-1.6.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2297fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675\", \"files\": {}}",
         "dest": "cargo/vendor/twox-hash-1.6.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/typenum/typenum-1.15.0.crate",
         "sha256": "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987",
-        "dest": "cargo/vendor",
-        "dest-filename": "typenum-1.15.0.crate"
+        "dest": "cargo/vendor/typenum-1.15.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987\", \"files\": {}}",
         "dest": "cargo/vendor/typenum-1.15.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ubyte/ubyte-0.10.3.crate",
         "sha256": "c81f0dae7d286ad0d9366d7679a77934cfc3cf3a8d67e82669794412b2368fe6",
-        "dest": "cargo/vendor",
-        "dest-filename": "ubyte-0.10.3.crate"
+        "dest": "cargo/vendor/ubyte-0.10.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c81f0dae7d286ad0d9366d7679a77934cfc3cf3a8d67e82669794412b2368fe6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c81f0dae7d286ad0d9366d7679a77934cfc3cf3a8d67e82669794412b2368fe6\", \"files\": {}}",
         "dest": "cargo/vendor/ubyte-0.10.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/ucd-trie/ucd-trie-0.1.5.crate",
         "sha256": "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81",
-        "dest": "cargo/vendor",
-        "dest-filename": "ucd-trie-0.1.5.crate"
+        "dest": "cargo/vendor/ucd-trie-0.1.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81\", \"files\": {}}",
         "dest": "cargo/vendor/ucd-trie-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/uncased/uncased-0.9.7.crate",
         "sha256": "09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622",
-        "dest": "cargo/vendor",
-        "dest-filename": "uncased-0.9.7.crate"
+        "dest": "cargo/vendor/uncased-0.9.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2209b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"09b01702b0fd0b3fadcf98e098780badda8742d4f4a7676615cad90e8ac73622\", \"files\": {}}",
         "dest": "cargo/vendor/uncased-0.9.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicase/unicase-2.6.0.crate",
         "sha256": "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicase-2.6.0.crate"
+        "dest": "cargo/vendor/unicase-2.6.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2250f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6\", \"files\": {}}",
         "dest": "cargo/vendor/unicase-2.6.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicode-bidi/unicode-bidi-0.3.8.crate",
         "sha256": "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicode-bidi-0.3.8.crate"
+        "dest": "cargo/vendor/unicode-bidi-0.3.8"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992\", \"files\": {}}",
         "dest": "cargo/vendor/unicode-bidi-0.3.8",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicode-ident/unicode-ident-1.0.3.crate",
         "sha256": "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicode-ident-1.0.3.crate"
+        "dest": "cargo/vendor/unicode-ident-1.0.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf\", \"files\": {}}",
         "dest": "cargo/vendor/unicode-ident-1.0.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicode-normalization/unicode-normalization-0.1.21.crate",
         "sha256": "854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicode-normalization-0.1.21.crate"
+        "dest": "cargo/vendor/unicode-normalization-0.1.21"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"854cbdc4f7bc6ae19c820d44abdc3277ac3e1b2b93db20a636825d9322fb60e6\", \"files\": {}}",
         "dest": "cargo/vendor/unicode-normalization-0.1.21",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicode-segmentation/unicode-segmentation-1.9.0.crate",
         "sha256": "7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicode-segmentation-1.9.0.crate"
+        "dest": "cargo/vendor/unicode-segmentation-1.9.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7e8820f5d777f6224dc4be3632222971ac30164d4a258d595640799554ebfd99\", \"files\": {}}",
         "dest": "cargo/vendor/unicode-segmentation-1.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicode-width/unicode-width-0.1.9.crate",
         "sha256": "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicode-width-0.1.9.crate"
+        "dest": "cargo/vendor/unicode-width-0.1.9"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973\", \"files\": {}}",
         "dest": "cargo/vendor/unicode-width-0.1.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/unicode-xid/unicode-xid-0.2.3.crate",
         "sha256": "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04",
-        "dest": "cargo/vendor",
-        "dest-filename": "unicode-xid-0.2.3.crate"
+        "dest": "cargo/vendor/unicode-xid-0.2.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04\", \"files\": {}}",
         "dest": "cargo/vendor/unicode-xid-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/universal-hash/universal-hash-0.4.1.crate",
         "sha256": "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05",
-        "dest": "cargo/vendor",
-        "dest-filename": "universal-hash-0.4.1.crate"
+        "dest": "cargo/vendor/universal-hash-0.4.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05\", \"files\": {}}",
         "dest": "cargo/vendor/universal-hash-0.4.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/untrusted/untrusted-0.7.1.crate",
         "sha256": "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a",
-        "dest": "cargo/vendor",
-        "dest-filename": "untrusted-0.7.1.crate"
+        "dest": "cargo/vendor/untrusted-0.7.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a\", \"files\": {}}",
         "dest": "cargo/vendor/untrusted-0.7.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/url/url-2.3.0.crate",
         "sha256": "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3",
-        "dest": "cargo/vendor",
-        "dest-filename": "url-2.3.0.crate"
+        "dest": "cargo/vendor/url-2.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2222fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3\", \"files\": {}}",
         "dest": "cargo/vendor/url-2.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/utf-8/utf-8-0.7.6.crate",
         "sha256": "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9",
-        "dest": "cargo/vendor",
-        "dest-filename": "utf-8-0.7.6.crate"
+        "dest": "cargo/vendor/utf-8-0.7.6"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2209cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9\", \"files\": {}}",
         "dest": "cargo/vendor/utf-8-0.7.6",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/valuable/valuable-0.1.0.crate",
         "sha256": "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d",
-        "dest": "cargo/vendor",
-        "dest-filename": "valuable-0.1.0.crate"
+        "dest": "cargo/vendor/valuable-0.1.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d\", \"files\": {}}",
         "dest": "cargo/vendor/valuable-0.1.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/vcpkg/vcpkg-0.2.15.crate",
         "sha256": "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426",
-        "dest": "cargo/vendor",
-        "dest-filename": "vcpkg-0.2.15.crate"
+        "dest": "cargo/vendor/vcpkg-0.2.15"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426\", \"files\": {}}",
         "dest": "cargo/vendor/vcpkg-0.2.15",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/veloren-serverbrowser-api/veloren-serverbrowser-api-0.2.0.crate",
         "sha256": "3974631142a04d38d765a52cd625d01b2b5632a8e50e9b22509f1c6f14ab01f8",
-        "dest": "cargo/vendor",
-        "dest-filename": "veloren-serverbrowser-api-0.2.0.crate"
+        "dest": "cargo/vendor/veloren-serverbrowser-api-0.2.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223974631142a04d38d765a52cd625d01b2b5632a8e50e9b22509f1c6f14ab01f8%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3974631142a04d38d765a52cd625d01b2b5632a8e50e9b22509f1c6f14ab01f8\", \"files\": {}}",
         "dest": "cargo/vendor/veloren-serverbrowser-api-0.2.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/version_check/version_check-0.9.4.crate",
         "sha256": "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f",
-        "dest": "cargo/vendor",
-        "dest-filename": "version_check-0.9.4.crate"
+        "dest": "cargo/vendor/version_check-0.9.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2249874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f\", \"files\": {}}",
         "dest": "cargo/vendor/version_check-0.9.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/want/want-0.3.0.crate",
         "sha256": "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0",
-        "dest": "cargo/vendor",
-        "dest-filename": "want-0.3.0.crate"
+        "dest": "cargo/vendor/want-0.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%221ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0\", \"files\": {}}",
         "dest": "cargo/vendor/want-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasi/wasi-0.9.0+wasi-snapshot-preview1.crate",
         "sha256": "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasi-0.9.0+wasi-snapshot-preview1.crate"
+        "dest": "cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519\", \"files\": {}}",
         "dest": "cargo/vendor/wasi-0.9.0+wasi-snapshot-preview1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasi/wasi-0.10.0+wasi-snapshot-preview1.crate",
         "sha256": "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasi-0.10.0+wasi-snapshot-preview1.crate"
+        "dest": "cargo/vendor/wasi-0.10.0+wasi-snapshot-preview1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%221a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f\", \"files\": {}}",
         "dest": "cargo/vendor/wasi-0.10.0+wasi-snapshot-preview1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasi/wasi-0.11.0+wasi-snapshot-preview1.crate",
         "sha256": "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasi-0.11.0+wasi-snapshot-preview1.crate"
+        "dest": "cargo/vendor/wasi-0.11.0+wasi-snapshot-preview1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423\", \"files\": {}}",
         "dest": "cargo/vendor/wasi-0.11.0+wasi-snapshot-preview1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-bindgen/wasm-bindgen-0.2.82.crate",
         "sha256": "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-bindgen-0.2.82.crate"
+        "dest": "cargo/vendor/wasm-bindgen-0.2.82"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d\", \"files\": {}}",
         "dest": "cargo/vendor/wasm-bindgen-0.2.82",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-bindgen-backend/wasm-bindgen-backend-0.2.82.crate",
         "sha256": "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-bindgen-backend-0.2.82.crate"
+        "dest": "cargo/vendor/wasm-bindgen-backend-0.2.82"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f\", \"files\": {}}",
         "dest": "cargo/vendor/wasm-bindgen-backend-0.2.82",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-bindgen-futures/wasm-bindgen-futures-0.4.32.crate",
         "sha256": "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-bindgen-futures-0.4.32.crate"
+        "dest": "cargo/vendor/wasm-bindgen-futures-0.4.32"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad\", \"files\": {}}",
         "dest": "cargo/vendor/wasm-bindgen-futures-0.4.32",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-bindgen-macro/wasm-bindgen-macro-0.2.82.crate",
         "sha256": "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-bindgen-macro-0.2.82.crate"
+        "dest": "cargo/vendor/wasm-bindgen-macro-0.2.82"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602\", \"files\": {}}",
         "dest": "cargo/vendor/wasm-bindgen-macro-0.2.82",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-bindgen-macro-support/wasm-bindgen-macro-support-0.2.82.crate",
         "sha256": "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-bindgen-macro-support-0.2.82.crate"
+        "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.82"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da\", \"files\": {}}",
         "dest": "cargo/vendor/wasm-bindgen-macro-support-0.2.82",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-bindgen-shared/wasm-bindgen-shared-0.2.82.crate",
         "sha256": "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-bindgen-shared-0.2.82.crate"
+        "dest": "cargo/vendor/wasm-bindgen-shared-0.2.82"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a\", \"files\": {}}",
         "dest": "cargo/vendor/wasm-bindgen-shared-0.2.82",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wasm-timer/wasm-timer-0.2.5.crate",
         "sha256": "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f",
-        "dest": "cargo/vendor",
-        "dest-filename": "wasm-timer-0.2.5.crate"
+        "dest": "cargo/vendor/wasm-timer-0.2.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f\", \"files\": {}}",
         "dest": "cargo/vendor/wasm-timer-0.2.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wayland-client/wayland-client-0.29.5.crate",
         "sha256": "3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715",
-        "dest": "cargo/vendor",
-        "dest-filename": "wayland-client-0.29.5.crate"
+        "dest": "cargo/vendor/wayland-client-0.29.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%223f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"3f3b068c05a039c9f755f881dc50f01732214f5685e379829759088967c46715\", \"files\": {}}",
         "dest": "cargo/vendor/wayland-client-0.29.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wayland-commons/wayland-commons-0.29.5.crate",
         "sha256": "8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902",
-        "dest": "cargo/vendor",
-        "dest-filename": "wayland-commons-0.29.5.crate"
+        "dest": "cargo/vendor/wayland-commons-0.29.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8691f134d584a33a6606d9d717b95c4fa20065605f798a3f350d78dced02a902\", \"files\": {}}",
         "dest": "cargo/vendor/wayland-commons-0.29.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wayland-cursor/wayland-cursor-0.29.5.crate",
         "sha256": "6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661",
-        "dest": "cargo/vendor",
-        "dest-filename": "wayland-cursor-0.29.5.crate"
+        "dest": "cargo/vendor/wayland-cursor-0.29.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6865c6b66f13d6257bef1cd40cbfe8ef2f150fb8ebbdb1e8e873455931377661\", \"files\": {}}",
         "dest": "cargo/vendor/wayland-cursor-0.29.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wayland-protocols/wayland-protocols-0.29.5.crate",
         "sha256": "b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6",
-        "dest": "cargo/vendor",
-        "dest-filename": "wayland-protocols-0.29.5.crate"
+        "dest": "cargo/vendor/wayland-protocols-0.29.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b950621f9354b322ee817a23474e479b34be96c2e909c14f7bc0100e9a970bc6\", \"files\": {}}",
         "dest": "cargo/vendor/wayland-protocols-0.29.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wayland-scanner/wayland-scanner-0.29.5.crate",
         "sha256": "8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53",
-        "dest": "cargo/vendor",
-        "dest-filename": "wayland-scanner-0.29.5.crate"
+        "dest": "cargo/vendor/wayland-scanner-0.29.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8f4303d8fa22ab852f789e75a967f0a2cdc430a607751c0499bada3e451cbd53\", \"files\": {}}",
         "dest": "cargo/vendor/wayland-scanner-0.29.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wayland-sys/wayland-sys-0.29.5.crate",
         "sha256": "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4",
-        "dest": "cargo/vendor",
-        "dest-filename": "wayland-sys-0.29.5.crate"
+        "dest": "cargo/vendor/wayland-sys-0.29.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4\", \"files\": {}}",
         "dest": "cargo/vendor/wayland-sys-0.29.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/web-sys/web-sys-0.3.57.crate",
         "sha256": "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283",
-        "dest": "cargo/vendor",
-        "dest-filename": "web-sys-0.3.57.crate"
+        "dest": "cargo/vendor/web-sys-0.3.57"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%227b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283\", \"files\": {}}",
         "dest": "cargo/vendor/web-sys-0.3.57",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/webpki/webpki-0.22.0.crate",
         "sha256": "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd",
-        "dest": "cargo/vendor",
-        "dest-filename": "webpki-0.22.0.crate"
+        "dest": "cargo/vendor/webpki-0.22.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd\", \"files\": {}}",
         "dest": "cargo/vendor/webpki-0.22.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/webpki-roots/webpki-roots-0.22.4.crate",
         "sha256": "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf",
-        "dest": "cargo/vendor",
-        "dest-filename": "webpki-roots-0.22.4.crate"
+        "dest": "cargo/vendor/webpki-roots-0.22.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf\", \"files\": {}}",
         "dest": "cargo/vendor/webpki-roots-0.22.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/weezl/weezl-0.1.7.crate",
         "sha256": "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb",
-        "dest": "cargo/vendor",
-        "dest-filename": "weezl-0.1.7.crate"
+        "dest": "cargo/vendor/weezl-0.1.7"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb\", \"files\": {}}",
         "dest": "cargo/vendor/weezl-0.1.7",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wgpu/wgpu-0.12.0.crate",
         "sha256": "b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567",
-        "dest": "cargo/vendor",
-        "dest-filename": "wgpu-0.12.0.crate"
+        "dest": "cargo/vendor/wgpu-0.12.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b97cd781ff044d6d697b632a2e212032c2e957d1afaa21dbf58069cbb8f78567\", \"files\": {}}",
         "dest": "cargo/vendor/wgpu-0.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wgpu-core/wgpu-core-0.12.2.crate",
         "sha256": "c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d",
-        "dest": "cargo/vendor",
-        "dest-filename": "wgpu-core-0.12.2.crate"
+        "dest": "cargo/vendor/wgpu-core-0.12.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c4688c000eb841ca55f7b35db659b78d6e1cd77d7caf8fb929f4e181f754047d\", \"files\": {}}",
         "dest": "cargo/vendor/wgpu-core-0.12.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wgpu-hal/wgpu-hal-0.12.5.crate",
         "sha256": "d684ea6a34974a2fc19f1dfd183d11a62e22d75c4f187a574bb1224df8e056c2",
-        "dest": "cargo/vendor",
-        "dest-filename": "wgpu-hal-0.12.5.crate"
+        "dest": "cargo/vendor/wgpu-hal-0.12.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d684ea6a34974a2fc19f1dfd183d11a62e22d75c4f187a574bb1224df8e056c2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d684ea6a34974a2fc19f1dfd183d11a62e22d75c4f187a574bb1224df8e056c2\", \"files\": {}}",
         "dest": "cargo/vendor/wgpu-hal-0.12.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wgpu-types/wgpu-types-0.12.0.crate",
         "sha256": "549533d9e1cdd4b4cda7718d33ff500fc4c34b5467b71d76b547ae0324f3b2a2",
-        "dest": "cargo/vendor",
-        "dest-filename": "wgpu-types-0.12.0.crate"
+        "dest": "cargo/vendor/wgpu-types-0.12.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22549533d9e1cdd4b4cda7718d33ff500fc4c34b5467b71d76b547ae0324f3b2a2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"549533d9e1cdd4b4cda7718d33ff500fc4c34b5467b71d76b547ae0324f3b2a2\", \"files\": {}}",
         "dest": "cargo/vendor/wgpu-types-0.12.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/wgpu_glyph/wgpu_glyph-0.16.0.crate",
         "sha256": "8134edb15ae465caf308125646c9e98bdef7398cdefc69227ac77a5eb795e7fe",
-        "dest": "cargo/vendor",
-        "dest-filename": "wgpu_glyph-0.16.0.crate"
+        "dest": "cargo/vendor/wgpu_glyph-0.16.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%228134edb15ae465caf308125646c9e98bdef7398cdefc69227ac77a5eb795e7fe%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"8134edb15ae465caf308125646c9e98bdef7398cdefc69227ac77a5eb795e7fe\", \"files\": {}}",
         "dest": "cargo/vendor/wgpu_glyph-0.16.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winapi/winapi-0.3.9.crate",
         "sha256": "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
-        "dest": "cargo/vendor",
-        "dest-filename": "winapi-0.3.9.crate"
+        "dest": "cargo/vendor/winapi-0.3.9"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%225c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419\", \"files\": {}}",
         "dest": "cargo/vendor/winapi-0.3.9",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winapi-i686-pc-windows-gnu/winapi-i686-pc-windows-gnu-0.4.0.crate",
         "sha256": "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6",
-        "dest": "cargo/vendor",
-        "dest-filename": "winapi-i686-pc-windows-gnu-0.4.0.crate"
+        "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6\", \"files\": {}}",
         "dest": "cargo/vendor/winapi-i686-pc-windows-gnu-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winapi-util/winapi-util-0.1.5.crate",
         "sha256": "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178",
-        "dest": "cargo/vendor",
-        "dest-filename": "winapi-util-0.1.5.crate"
+        "dest": "cargo/vendor/winapi-util-0.1.5"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2270ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178\", \"files\": {}}",
         "dest": "cargo/vendor/winapi-util-0.1.5",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winapi-wsapoll/winapi-wsapoll-0.1.1.crate",
         "sha256": "44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e",
-        "dest": "cargo/vendor",
-        "dest-filename": "winapi-wsapoll-0.1.1.crate"
+        "dest": "cargo/vendor/winapi-wsapoll-0.1.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2244c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"44c17110f57155602a80dca10be03852116403c9ff3cd25b079d666f2aa3df6e\", \"files\": {}}",
         "dest": "cargo/vendor/winapi-wsapoll-0.1.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/winapi-x86_64-pc-windows-gnu-0.4.0.crate",
         "sha256": "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
-        "dest": "cargo/vendor",
-        "dest-filename": "winapi-x86_64-pc-windows-gnu-0.4.0.crate"
+        "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f\", \"files\": {}}",
         "dest": "cargo/vendor/winapi-x86_64-pc-windows-gnu-0.4.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/window_clipboard/window_clipboard-0.2.3.crate",
         "sha256": "b47d7fb4df5cd1fea61e5ee3841380f54359bac814e227d8f72709f4f193f8cf",
-        "dest": "cargo/vendor",
-        "dest-filename": "window_clipboard-0.2.3.crate"
+        "dest": "cargo/vendor/window_clipboard-0.2.3"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b47d7fb4df5cd1fea61e5ee3841380f54359bac814e227d8f72709f4f193f8cf%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b47d7fb4df5cd1fea61e5ee3841380f54359bac814e227d8f72709f4f193f8cf\", \"files\": {}}",
         "dest": "cargo/vendor/window_clipboard-0.2.3",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows/windows-0.32.0.crate",
         "sha256": "fbedf6db9096bc2364adce0ae0aa636dcd89f3c3f2cd67947062aaf0ca2a10ec",
-        "dest": "cargo/vendor",
-        "dest-filename": "windows-0.32.0.crate"
+        "dest": "cargo/vendor/windows-0.32.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22fbedf6db9096bc2364adce0ae0aa636dcd89f3c3f2cd67947062aaf0ca2a10ec%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"fbedf6db9096bc2364adce0ae0aa636dcd89f3c3f2cd67947062aaf0ca2a10ec\", \"files\": {}}",
         "dest": "cargo/vendor/windows-0.32.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows-sys/windows-sys-0.36.1.crate",
         "sha256": "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2",
-        "dest": "cargo/vendor",
-        "dest-filename": "windows-sys-0.36.1.crate"
+        "dest": "cargo/vendor/windows-sys-0.36.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2\", \"files\": {}}",
         "dest": "cargo/vendor/windows-sys-0.36.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.32.0.crate",
         "sha256": "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5",
-        "dest": "cargo/vendor",
-        "dest-filename": "windows_aarch64_msvc-0.32.0.crate"
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.32.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5\", \"files\": {}}",
         "dest": "cargo/vendor/windows_aarch64_msvc-0.32.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_aarch64_msvc/windows_aarch64_msvc-0.36.1.crate",
         "sha256": "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47",
-        "dest": "cargo/vendor",
-        "dest-filename": "windows_aarch64_msvc-0.36.1.crate"
+        "dest": "cargo/vendor/windows_aarch64_msvc-0.36.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47\", \"files\": {}}",
         "dest": "cargo/vendor/windows_aarch64_msvc-0.36.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.32.0.crate",
         "sha256": "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615",
-        "dest": "cargo/vendor",
-        "dest-filename": "windows_i686_gnu-0.32.0.crate"
+        "dest": "cargo/vendor/windows_i686_gnu-0.32.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615\", \"files\": {}}",
         "dest": "cargo/vendor/windows_i686_gnu-0.32.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_i686_gnu/windows_i686_gnu-0.36.1.crate",
         "sha256": "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6",
-        "dest": "cargo/vendor",
-        "dest-filename": "windows_i686_gnu-0.36.1.crate"
+        "dest": "cargo/vendor/windows_i686_gnu-0.36.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6\", \"files\": {}}",
         "dest": "cargo/vendor/windows_i686_gnu-0.36.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.32.0.crate",
         "sha256": "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172",
-        "dest": "cargo/vendor",
-        "dest-filename": "windows_i686_msvc-0.32.0.crate"
+        "dest": "cargo/vendor/windows_i686_msvc-0.32.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172\", \"files\": {}}",
         "dest": "cargo/vendor/windows_i686_msvc-0.32.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_i686_msvc/windows_i686_msvc-0.36.1.crate",
         "sha256": "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024",
-        "dest": "cargo/vendor",
-        "dest-filename": "windows_i686_msvc-0.36.1.crate"
+        "dest": "cargo/vendor/windows_i686_msvc-0.36.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024\", \"files\": {}}",
         "dest": "cargo/vendor/windows_i686_msvc-0.36.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.32.0.crate",
         "sha256": "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc",
-        "dest": "cargo/vendor",
-        "dest-filename": "windows_x86_64_gnu-0.32.0.crate"
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.32.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc\", \"files\": {}}",
         "dest": "cargo/vendor/windows_x86_64_gnu-0.32.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_x86_64_gnu/windows_x86_64_gnu-0.36.1.crate",
         "sha256": "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1",
-        "dest": "cargo/vendor",
-        "dest-filename": "windows_x86_64_gnu-0.36.1.crate"
+        "dest": "cargo/vendor/windows_x86_64_gnu-0.36.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%224dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1\", \"files\": {}}",
         "dest": "cargo/vendor/windows_x86_64_gnu-0.36.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.32.0.crate",
         "sha256": "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316",
-        "dest": "cargo/vendor",
-        "dest-filename": "windows_x86_64_msvc-0.32.0.crate"
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.32.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316\", \"files\": {}}",
         "dest": "cargo/vendor/windows_x86_64_msvc-0.32.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/windows_x86_64_msvc/windows_x86_64_msvc-0.36.1.crate",
         "sha256": "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680",
-        "dest": "cargo/vendor",
-        "dest-filename": "windows_x86_64_msvc-0.36.1.crate"
+        "dest": "cargo/vendor/windows_x86_64_msvc-0.36.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680\", \"files\": {}}",
         "dest": "cargo/vendor/windows_x86_64_msvc-0.36.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winit/winit-0.26.1.crate",
         "sha256": "9b43cc931d58b99461188607efd7acb2a093e65fc621f54cad78517a6063e73a",
-        "dest": "cargo/vendor",
-        "dest-filename": "winit-0.26.1.crate"
+        "dest": "cargo/vendor/winit-0.26.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229b43cc931d58b99461188607efd7acb2a093e65fc621f54cad78517a6063e73a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9b43cc931d58b99461188607efd7acb2a093e65fc621f54cad78517a6063e73a\", \"files\": {}}",
         "dest": "cargo/vendor/winit-0.26.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winreg/winreg-0.10.1.crate",
         "sha256": "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d",
-        "dest": "cargo/vendor",
-        "dest-filename": "winreg-0.10.1.crate"
+        "dest": "cargo/vendor/winreg-0.10.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2280d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d\", \"files\": {}}",
         "dest": "cargo/vendor/winreg-0.10.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/winres/winres-0.1.12.crate",
         "sha256": "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c",
-        "dest": "cargo/vendor",
-        "dest-filename": "winres-0.1.12.crate"
+        "dest": "cargo/vendor/winres-0.1.12"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c\", \"files\": {}}",
         "dest": "cargo/vendor/winres-0.1.12",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/x11-dl/x11-dl-2.20.0.crate",
         "sha256": "0c83627bc137605acc00bb399c7b908ef460b621fc37c953db2b09f88c449ea6",
-        "dest": "cargo/vendor",
-        "dest-filename": "x11-dl-2.20.0.crate"
+        "dest": "cargo/vendor/x11-dl-2.20.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%220c83627bc137605acc00bb399c7b908ef460b621fc37c953db2b09f88c449ea6%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"0c83627bc137605acc00bb399c7b908ef460b621fc37c953db2b09f88c449ea6\", \"files\": {}}",
         "dest": "cargo/vendor/x11-dl-2.20.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/x11rb/x11rb-0.9.0.crate",
         "sha256": "6e99be55648b3ae2a52342f9a870c0e138709a3493261ce9b469afe6e4df6d8a",
-        "dest": "cargo/vendor",
-        "dest-filename": "x11rb-0.9.0.crate"
+        "dest": "cargo/vendor/x11rb-0.9.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%226e99be55648b3ae2a52342f9a870c0e138709a3493261ce9b469afe6e4df6d8a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"6e99be55648b3ae2a52342f9a870c0e138709a3493261ce9b469afe6e4df6d8a\", \"files\": {}}",
         "dest": "cargo/vendor/x11rb-0.9.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/xcursor/xcursor-0.3.4.crate",
         "sha256": "463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7",
-        "dest": "cargo/vendor",
-        "dest-filename": "xcursor-0.3.4.crate"
+        "dest": "cargo/vendor/xcursor-0.3.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"463705a63313cd4301184381c5e8042f0a7e9b4bb63653f216311d4ae74690b7\", \"files\": {}}",
         "dest": "cargo/vendor/xcursor-0.3.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/xi-unicode/xi-unicode-0.3.0.crate",
         "sha256": "a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a",
-        "dest": "cargo/vendor",
-        "dest-filename": "xi-unicode-0.3.0.crate"
+        "dest": "cargo/vendor/xi-unicode-0.3.0"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"a67300977d3dc3f8034dae89778f502b6ba20b269527b3223ba59c0cf393bb8a\", \"files\": {}}",
         "dest": "cargo/vendor/xi-unicode-0.3.0",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/xml-rs/xml-rs-0.8.4.crate",
         "sha256": "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3",
-        "dest": "cargo/vendor",
-        "dest-filename": "xml-rs-0.8.4.crate"
+        "dest": "cargo/vendor/xml-rs-0.8.4"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%22d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3\", \"files\": {}}",
         "dest": "cargo/vendor/xml-rs-0.8.4",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/xml5ever/xml5ever-0.16.2.crate",
         "sha256": "9234163818fd8e2418fcde330655e757900d4236acd8cc70fef345ef91f6d865",
-        "dest": "cargo/vendor",
-        "dest-filename": "xml5ever-0.16.2.crate"
+        "dest": "cargo/vendor/xml5ever-0.16.2"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%229234163818fd8e2418fcde330655e757900d4236acd8cc70fef345ef91f6d865%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"9234163818fd8e2418fcde330655e757900d4236acd8cc70fef345ef91f6d865\", \"files\": {}}",
         "dest": "cargo/vendor/xml5ever-0.16.2",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/yansi/yansi-0.5.1.crate",
         "sha256": "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec",
-        "dest": "cargo/vendor",
-        "dest-filename": "yansi-0.5.1.crate"
+        "dest": "cargo/vendor/yansi-0.5.1"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2209041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec\", \"files\": {}}",
         "dest": "cargo/vendor/yansi-0.5.1",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "file",
+        "type": "archive",
+        "archive-type": "tar-gzip",
         "url": "https://static.crates.io/crates/zip/zip-0.5.13.crate",
         "sha256": "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815",
-        "dest": "cargo/vendor",
-        "dest-filename": "zip-0.5.13.crate"
+        "dest": "cargo/vendor/zip-0.5.13"
     },
     {
-        "type": "file",
-        "url": "data:%7B%22package%22%3A%20%2293ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815%22%2C%20%22files%22%3A%20%7B%7D%7D",
+        "type": "inline",
+        "contents": "{\"package\": \"93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815\", \"files\": {}}",
         "dest": "cargo/vendor/zip-0.5.13",
         "dest-filename": ".cargo-checksum.json"
     },
     {
-        "type": "shell",
-        "dest": "cargo/vendor",
-        "commands": [
-            "for c in *.crate; do tar -xf $c; done"
-        ]
-    },
-    {
-        "type": "file",
-        "url": "data:%5Bsource.vendored-sources%5D%0Adirectory%20%3D%20%22cargo/vendor%22%0A%0A%5Bsource.crates-io%5D%0Areplace-with%20%3D%20%22vendored-sources%22%0A%0A%5Bsource.%22https%3A//github.com/xampprocky/octocrab%22%5D%0Agit%20%3D%20%22https%3A//github.com/xampprocky/octocrab%22%0Areplace-with%20%3D%20%22vendored-sources%22%0Arev%20%3D%20%22c78edcd87fa5edcd5a6d0d0878b2a8d020802c40%22%0A",
+        "type": "inline",
+        "contents": "[source.vendored-sources]\ndirectory = \"cargo/vendor\"\n\n[source.crates-io]\nreplace-with = \"vendored-sources\"\n\n[source.\"https://github.com/xampprocky/octocrab\"]\ngit = \"https://github.com/xampprocky/octocrab\"\nreplace-with = \"vendored-sources\"\nrev = \"c78edcd87fa5edcd5a6d0d0878b2a8d020802c40\"\n",
         "dest": "cargo",
         "dest-filename": "config"
     }

--- a/net.veloren.airshipper.yaml
+++ b/net.veloren.airshipper.yaml
@@ -14,16 +14,17 @@ finish-args:
   - --share=ipc
   - --device=dri
 build-options : {
-  append-path : "/usr/lib/sdk/rust-nightly/bin",
-  env : {
-    "CARGO_HOME" : "/run/build/airshipper/cargo",
-    "RUST_BACKTRACE" : "1"
-    }
+  append-path : "/usr/lib/sdk/rust-nightly/bin"
 }
 
 modules:
   - name : airshipper
     buildsystem : simple
+    build-options:
+      env : {
+        "CARGO_HOME" : "/run/build/airshipper/cargo",
+        "RUST_BACKTRACE" : "1"
+      }
     build-commands : 
       - cargo --offline fetch --manifest-path Cargo.toml 
       - cargo --offline build --bin airshipper --release 


### PR DESCRIPTION
Please update flatpak-builder-tools you're using locally. Older flatpak-cargo-generator versions produce sources manifests that will be considered invalid by the upcoming flatpak linter.