### PR TITLE
Add aarch64 to build targets.

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,3 @@
 {
-    "only-arches": ["x86_64"]
+    "only-arches": ["x86_64", "aarch64"]
 }


### PR DESCRIPTION
Veloren builds for aarch64 are now available through airshipper, so it makes sense to build for airshipper for aarch64 too.
Resolves: #18 